### PR TITLE
Add rules for double gameweek and free hit in blank gameweek

### DIFF
--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -28,6 +28,24 @@ function toFloat(v) {
   return Number.isFinite(n) ? n : 0;
 }
 
+/**
+ * Returns the set of team IDs that have two or more fixtures in the given gameweek.
+ */
+function getDoubleGameweekTeamIds(fixtures, gw) {
+  const fixtureCount = {};
+  fixtures
+    .filter((f) => f.event === gw)
+    .forEach((f) => {
+      fixtureCount[f.team_h] = (fixtureCount[f.team_h] || 0) + 1;
+      fixtureCount[f.team_a] = (fixtureCount[f.team_a] || 0) + 1;
+    });
+  return new Set(
+    Object.entries(fixtureCount)
+      .filter(([, count]) => count >= 2)
+      .map(([id]) => parseInt(id, 10)),
+  );
+}
+
 // ─── Rules ───────────────────────────────────────────────────────────────────
 
 const RULES = [
@@ -40,29 +58,18 @@ const RULES = [
     generate(ctx) {
       const { fixtures, targetGW, bootstrap, squadPlayers } = ctx;
 
-      const teamFixtureCount = {};
-      fixtures
-        .filter((f) => f.event === targetGW)
-        .forEach((f) => {
-          teamFixtureCount[f.team_h] = (teamFixtureCount[f.team_h] || 0) + 1;
-          teamFixtureCount[f.team_a] = (teamFixtureCount[f.team_a] || 0) + 1;
-        });
-
-      const dgwTeams = Object.entries(teamFixtureCount)
-        .filter(([, count]) => count >= 2)
-        .map(([id]) => bootstrap.teams.find((t) => t.id === parseInt(id, 10)))
-        .filter(Boolean);
+      const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, targetGW);
+      const dgwTeams = bootstrap.teams.filter((t) => dgwTeamIds.has(t.id));
 
       if (dgwTeams.length === 0) return null;
-
-      const dgwTeamIds = new Set(dgwTeams.map((t) => t.id));
 
       // If squad loaded, note which squad players benefit
       let squadNote = '';
       if (squadPlayers && squadPlayers.length > 0) {
         const dgwSquadPlayers = squadPlayers.filter((p) => dgwTeamIds.has(p.team));
         if (dgwSquadPlayers.length > 0) {
-          squadNote = ` You already have ${dgwSquadPlayers.map((p) => p.web_name).join(', ')} from ${dgwSquadPlayers.length === 1 ? 'this team' : 'these teams'}.`;
+          const ownedDgwTeamIds = new Set(dgwSquadPlayers.map((p) => p.team));
+          squadNote = ` You already have ${dgwSquadPlayers.map((p) => p.web_name).join(', ')} from ${ownedDgwTeamIds.size === 1 ? 'this team' : 'these teams'}.`;
         }
       }
 
@@ -379,18 +386,7 @@ const RULES = [
         if (blankTeamIds.size >= 6) {
           // Free Hit blank GW scenario — suggest holding transfers and targeting DGW players instead
           const dgwGW = targetGW + 1;
-          const dgwTeamFixtureCount = {};
-          fixtures
-            .filter((f) => f.event === dgwGW)
-            .forEach((f) => {
-              dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
-              dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
-            });
-          const dgwTeamIds = new Set(
-            Object.entries(dgwTeamFixtureCount)
-              .filter(([, count]) => count >= 2)
-              .map(([id]) => parseInt(id, 10)),
-          );
+          const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, dgwGW);
 
           if (dgwTeamIds.size > 0) {
             // Find best DGW players not yet in squad
@@ -428,34 +424,24 @@ const RULES = [
     enabled: true,
     requiresSquad: false,
     generate(ctx) {
-      const { fixtures, targetGW, bootstrap, squadPlayers } = ctx;
+      const { fixtures, currentGW, bootstrap, squadPlayers } = ctx;
 
-      const planGW = targetGW + 1;
+      const planGW = currentGW + 1;
       if (planGW > 38) return null;
 
-      const teamFixtureCount = {};
-      fixtures
-        .filter((f) => f.event === planGW)
-        .forEach((f) => {
-          teamFixtureCount[f.team_h] = (teamFixtureCount[f.team_h] || 0) + 1;
-          teamFixtureCount[f.team_a] = (teamFixtureCount[f.team_a] || 0) + 1;
-        });
-
-      const dgwTeams = Object.entries(teamFixtureCount)
-        .filter(([, count]) => count >= 2)
-        .map(([id]) => bootstrap.teams.find((t) => t.id === parseInt(id, 10)))
-        .filter(Boolean);
+      const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, planGW);
+      const dgwTeams = bootstrap.teams.filter((t) => dgwTeamIds.has(t.id));
 
       if (dgwTeams.length === 0) return null;
 
-      const dgwTeamIds = new Set(dgwTeams.map((t) => t.id));
       const teamNames = dgwTeams.map((t) => t.name);
 
       let squadNote = '';
       if (squadPlayers && squadPlayers.length > 0) {
         const dgwSquadPlayers = squadPlayers.filter((p) => dgwTeamIds.has(p.team));
         if (dgwSquadPlayers.length > 0) {
-          squadNote = ` You already have ${dgwSquadPlayers.map((p) => p.web_name).join(', ')} from ${dgwSquadPlayers.length === 1 ? 'this team' : 'these teams'} — good position.`;
+          const ownedDgwTeamIds = new Set(dgwSquadPlayers.map((p) => p.team));
+          squadNote = ` You already have ${dgwSquadPlayers.map((p) => p.web_name).join(', ')} from ${ownedDgwTeamIds.size === 1 ? 'this team' : 'these teams'} — good position.`;
         }
       }
 
@@ -477,9 +463,9 @@ const RULES = [
     enabled: true,
     requiresSquad: false,
     generate(ctx) {
-      const { fixtures, targetGW, bootstrap, squadPicks, squadPlayers } = ctx;
+      const { fixtures, currentGW, bootstrap, squadPicks, squadPlayers } = ctx;
 
-      const blankGW = targetGW + 2;
+      const blankGW = currentGW + 2;
       if (blankGW > 38) return null;
 
       const teamsWithFixture = new Set(
@@ -496,7 +482,7 @@ const RULES = [
       // Only fire if a significant number of teams are blank (at least 6)
       if (blankCount < 6) return null;
 
-      // Check if Free Hit chip is still available
+      // Check if a chip is currently active (to warn against stacking chips)
       let freeHitNote = '';
       if (squadPicks && squadPicks.active_chip) {
         freeHitNote = ' Note: you currently have a chip active.';
@@ -539,18 +525,7 @@ const RULES = [
       const dgwGW = targetGW + 1;
       if (dgwGW > 38) return null;
 
-      const dgwTeamFixtureCount = {};
-      fixtures
-        .filter((f) => f.event === dgwGW)
-        .forEach((f) => {
-          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
-          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
-        });
-      const dgwTeamIds = new Set(
-        Object.entries(dgwTeamFixtureCount)
-          .filter(([, count]) => count >= 2)
-          .map(([id]) => parseInt(id, 10)),
-      );
+      const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, dgwGW);
       if (dgwTeamIds.size === 0) return null;
 
       const squadIds = new Set(squadPlayers.map((p) => p.id));
@@ -643,18 +618,7 @@ const RULES = [
       const dgwGW = targetGW + 1;
       if (dgwGW > 38) return null;
 
-      const dgwTeamFixtureCount = {};
-      fixtures
-        .filter((f) => f.event === dgwGW)
-        .forEach((f) => {
-          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
-          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
-        });
-      const dgwTeamIds = new Set(
-        Object.entries(dgwTeamFixtureCount)
-          .filter(([, count]) => count >= 2)
-          .map(([id]) => parseInt(id, 10)),
-      );
+      const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, dgwGW);
       if (dgwTeamIds.size === 0) return null;
 
       // Best DGW player in the squad (all 15) by predicted points
@@ -701,18 +665,7 @@ const RULES = [
       const dgwGW = targetGW + 1;
       if (dgwGW > 38) return null;
 
-      const dgwTeamFixtureCount = {};
-      fixtures
-        .filter((f) => f.event === dgwGW)
-        .forEach((f) => {
-          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
-          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
-        });
-      const dgwTeamIds = new Set(
-        Object.entries(dgwTeamFixtureCount)
-          .filter(([, count]) => count >= 2)
-          .map(([id]) => parseInt(id, 10)),
-      );
+      const dgwTeamIds = getDoubleGameweekTeamIds(fixtures, dgwGW);
       if (dgwTeamIds.size === 0) return null;
 
       // Bench = positions 12–15

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -427,7 +427,7 @@ const RULES = [
     enabled: true,
     requiresSquad: false,
     generate(ctx) {
-      const { fixtures, targetGW, bootstrap, squadPicks } = ctx;
+      const { fixtures, targetGW, bootstrap, squadPicks, squadPlayers } = ctx;
 
       const blankGW = targetGW + 2;
       if (blankGW > 38) return null;
@@ -439,7 +439,8 @@ const RULES = [
       );
 
       const totalTeams = bootstrap.teams.length;
-      const blankTeams = bootstrap.teams.filter((t) => !teamsWithFixture.has(t.id));
+      const blankTeamSet = new Set(bootstrap.teams.filter((t) => !teamsWithFixture.has(t.id)).map((t) => t.id));
+      const blankTeams = bootstrap.teams.filter((t) => blankTeamSet.has(t.id));
       const blankCount = blankTeams.length;
 
       // Only fire if a significant number of teams are blank (at least 6)
@@ -448,8 +449,18 @@ const RULES = [
       // Check if Free Hit chip is still available
       let freeHitNote = '';
       if (squadPicks && squadPicks.active_chip) {
-        // A chip is currently active — note it but still warn
         freeHitNote = ' Note: you currently have a chip active.';
+      }
+
+      // Count how many of the user's squad players are blanking
+      let squadBlankNote = '';
+      if (squadPlayers && squadPlayers.length > 0) {
+        const blankSquadPlayers = squadPlayers.filter((p) => blankTeamSet.has(p.team));
+        if (blankSquadPlayers.length > 0) {
+          squadBlankNote = ` ${blankSquadPlayers.length} of your players will blank: ${blankSquadPlayers.map((p) => p.web_name).join(', ')}.`;
+        } else {
+          squadBlankNote = ' None of your current players will blank.';
+        }
       }
 
       const teamNames = blankTeams.map((t) => t.name);
@@ -458,7 +469,7 @@ const RULES = [
         id: 'freehit-blank-gameweek',
         type: 'opportunity',
         title: `Consider Free Hit for GW${blankGW} Blanks`,
-        message: `GW${blankGW} has ${blankCount} of ${totalTeams} teams without a fixture (${teamNames.join(', ')}). This is prime territory for your Free Hit chip.${freeHitNote}`,
+        message: `GW${blankGW} has ${blankCount} of ${totalTeams} teams without a fixture (${teamNames.join(', ')}).${squadBlankNote} This is prime territory for your Free Hit chip.${freeHitNote}`,
         teams: blankTeams.map((t) => ({ id: t.id, name: t.name, shortName: t.short_name })),
         planGameweek: blankGW,
       };

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -526,47 +526,75 @@ const RULES = [
     },
   },
 
-  // ── 10. Differential / DGW Pick Opportunity ─────────────────────────────
+  // ── 10. DGW Differential Transfer Targets ────────────────────────────────
   {
-    id: 'differential-pick',
+    id: 'differential-pick-dgw',
     priority: 3,
     enabled: true,
     requiresSquad: true,
     generate(ctx) {
-      const { allPlayers, squadPlayers, targetGW, fixtures } = ctx;
+      const { allPlayers, squadPlayers, fixtures, targetGW } = ctx;
       if (!squadPlayers) return null;
 
-      const squadIds = new Set(squadPlayers.map((p) => p.id));
-
-      // Check if the next GW (targetGW + 1) is a DGW
       const dgwGW = targetGW + 1;
+      if (dgwGW > 38) return null;
+
       const dgwTeamFixtureCount = {};
-      if (dgwGW <= 38) {
-        fixtures
-          .filter((f) => f.event === dgwGW)
-          .forEach((f) => {
-            dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
-            dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
-          });
-      }
+      fixtures
+        .filter((f) => f.event === dgwGW)
+        .forEach((f) => {
+          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
+          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
+        });
       const dgwTeamIds = new Set(
         Object.entries(dgwTeamFixtureCount)
           .filter(([, count]) => count >= 2)
           .map(([id]) => parseInt(id, 10)),
       );
-      const hasDGW = dgwTeamIds.size > 0;
+      if (dgwTeamIds.size === 0) return null;
 
-      // DGW differentials: not in squad, from DGW teams, ownership < 25%, best predicted pts
-      const dgwCandidates = hasDGW
-        ? allPlayers
-            .filter((p) => !squadIds.has(p.id) && dgwTeamIds.has(p.team))
-            .filter((p) => toFloat(p.selected_by_percent) < 25)
-            .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
-            .slice(0, 3)
-        : [];
+      const squadIds = new Set(squadPlayers.map((p) => p.id));
+      const candidates = allPlayers
+        .filter((p) => !squadIds.has(p.id) && dgwTeamIds.has(p.team))
+        .filter((p) => toFloat(p.selected_by_percent) < 25)
+        .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
+        .slice(0, 3);
 
-      // General differentials: not in squad, low ownership, high ICT, good predicted pts
-      const generalCandidates = allPlayers
+      if (candidates.length === 0) return null;
+
+      const best = candidates[0];
+      const ownership = toFloat(best.selected_by_percent).toFixed(1);
+      const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
+      const price = (best.now_cost / 10).toFixed(1);
+
+      return {
+        id: 'differential-pick-dgw',
+        type: 'opportunity',
+        title: `Differential Transfer Targets`,
+        message: `${best.web_name} (£${price}m, ${ownership}% owned) is a standout differential for GW${dgwGW}'s double gameweek — predicted ${pts} pts with two fixtures.`,
+        players: candidates.map((p) => ({
+          id: p.id,
+          name: p.web_name,
+          price: p.now_cost / 10,
+          ownership: toFloat(p.selected_by_percent),
+          predictedPoints: toFloat(p.predicted_points || p.ep_next),
+        })),
+      };
+    },
+  },
+
+  // ── 11. General Transfer Targets ─────────────────────────────────────────
+  {
+    id: 'differential-pick-general',
+    priority: 3,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { allPlayers, squadPlayers, targetGW } = ctx;
+      if (!squadPlayers) return null;
+
+      const squadIds = new Set(squadPlayers.map((p) => p.id));
+      const candidates = allPlayers
         .filter((p) => !squadIds.has(p.id))
         .filter((p) => {
           const ownership = toFloat(p.selected_by_percent);
@@ -577,49 +605,26 @@ const RULES = [
         .sort((a, b) => toFloat(b.ict_index) - toFloat(a.ict_index))
         .slice(0, 3);
 
-      if (dgwCandidates.length === 0 && generalCandidates.length === 0) return null;
+      if (candidates.length === 0) return null;
 
-      const messageParts = [];
-
-      if (dgwCandidates.length > 0) {
-        const best = dgwCandidates[0];
-        const ownership = toFloat(best.selected_by_percent).toFixed(1);
-        const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
-        const price = (best.now_cost / 10).toFixed(1);
-        messageParts.push(`DGW${dgwGW} differential: ${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts with two fixtures.`);
-      }
-
-      if (generalCandidates.length > 0) {
-        const best = generalCandidates[0];
-        const ownership = toFloat(best.selected_by_percent).toFixed(1);
-        const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
-        const price = (best.now_cost / 10).toFixed(1);
-        messageParts.push(`General differential: ${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts with a strong ICT index.`);
-      }
+      const best = candidates[0];
+      const ownership = toFloat(best.selected_by_percent).toFixed(1);
+      const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
+      const price = (best.now_cost / 10).toFixed(1);
 
       return {
-        id: 'differential-pick',
+        id: 'differential-pick-general',
         type: 'opportunity',
-        title: hasDGW ? `Differential Targets (incl. DGW${dgwGW})` : 'Differential Opportunity',
-        message: messageParts.join('\n'),
-        players: [
-          ...dgwCandidates.map((p) => ({
-            id: p.id,
-            name: p.web_name,
-            price: p.now_cost / 10,
-            ownership: toFloat(p.selected_by_percent),
-            predictedPoints: toFloat(p.predicted_points || p.ep_next),
-            tag: `DGW${dgwGW}`,
-          })),
-          ...generalCandidates.map((p) => ({
-            id: p.id,
-            name: p.web_name,
-            price: p.now_cost / 10,
-            ownership: toFloat(p.selected_by_percent),
-            predictedPoints: toFloat(p.predicted_points || p.ep_next),
-            ictIndex: toFloat(p.ict_index),
-          })),
-        ],
+        title: 'Transfer Targets',
+        message: `${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts in GW${targetGW} with a strong ICT index.`,
+        players: candidates.map((p) => ({
+          id: p.id,
+          name: p.web_name,
+          price: p.now_cost / 10,
+          ownership: toFloat(p.selected_by_percent),
+          predictedPoints: toFloat(p.predicted_points || p.ep_next),
+          ictIndex: toFloat(p.ict_index),
+        })),
       };
     },
   },

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -482,7 +482,7 @@ const RULES = [
       // Only fire if a significant number of teams are blank (at least 6)
       if (blankCount < 6) return null;
 
-      // Check if a chip is currently active (to warn against stacking chips)
+      // Check if a chip is currently active
       let freeHitNote = '';
       if (squadPicks && squadPicks.active_chip) {
         freeHitNote = ' Note: you currently have a chip active.';

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -371,7 +371,101 @@ const RULES = [
     },
   },
 
-  // ── 8. Differential Pick Opportunity ─────────────────────────────────────
+  // ── 8. Plan Ahead: Double Gameweek Next+1 ────────────────────────────────
+  {
+    id: 'upcoming-double-gameweek',
+    priority: 1,
+    enabled: true,
+    requiresSquad: false,
+    generate(ctx) {
+      const { fixtures, targetGW, bootstrap, squadPlayers } = ctx;
+
+      const planGW = targetGW + 1;
+      if (planGW > 38) return null;
+
+      const teamFixtureCount = {};
+      fixtures
+        .filter((f) => f.event === planGW)
+        .forEach((f) => {
+          teamFixtureCount[f.team_h] = (teamFixtureCount[f.team_h] || 0) + 1;
+          teamFixtureCount[f.team_a] = (teamFixtureCount[f.team_a] || 0) + 1;
+        });
+
+      const dgwTeams = Object.entries(teamFixtureCount)
+        .filter(([, count]) => count >= 2)
+        .map(([id]) => bootstrap.teams.find((t) => t.id === parseInt(id, 10)))
+        .filter(Boolean);
+
+      if (dgwTeams.length === 0) return null;
+
+      const dgwTeamIds = new Set(dgwTeams.map((t) => t.id));
+      const teamNames = dgwTeams.map((t) => t.name);
+
+      let squadNote = '';
+      if (squadPlayers && squadPlayers.length > 0) {
+        const dgwSquadPlayers = squadPlayers.filter((p) => dgwTeamIds.has(p.team));
+        if (dgwSquadPlayers.length > 0) {
+          squadNote = ` You already have ${dgwSquadPlayers.map((p) => p.web_name).join(', ')} from ${dgwSquadPlayers.length === 1 ? 'this team' : 'these teams'} — good position.`;
+        }
+      }
+
+      return {
+        id: 'upcoming-double-gameweek',
+        type: 'opportunity',
+        title: `Plan Ahead: Double Gameweek ${planGW}`,
+        message: `GW${planGW} (next gameweek after this one) is a double gameweek for ${teamNames.join(', ')}. Use your free transfers this week to target players from ${dgwTeams.length === 1 ? 'this team' : 'these teams'} so you're set up to maximise points.${squadNote}`,
+        teams: dgwTeams.map((t) => ({ id: t.id, name: t.name, shortName: t.short_name })),
+        planGameweek: planGW,
+      };
+    },
+  },
+
+  // ── 9. Free Hit for Upcoming Blank Gameweek ───────────────────────────────
+  {
+    id: 'freehit-blank-gameweek',
+    priority: 1,
+    enabled: true,
+    requiresSquad: false,
+    generate(ctx) {
+      const { fixtures, targetGW, bootstrap, squadPicks } = ctx;
+
+      const blankGW = targetGW + 2;
+      if (blankGW > 38) return null;
+
+      const teamsWithFixture = new Set(
+        fixtures
+          .filter((f) => f.event === blankGW)
+          .flatMap((f) => [f.team_h, f.team_a]),
+      );
+
+      const totalTeams = bootstrap.teams.length;
+      const blankTeams = bootstrap.teams.filter((t) => !teamsWithFixture.has(t.id));
+      const blankCount = blankTeams.length;
+
+      // Only fire if a significant number of teams are blank (at least 6)
+      if (blankCount < 6) return null;
+
+      // Check if Free Hit chip is still available
+      let freeHitNote = '';
+      if (squadPicks && squadPicks.active_chip) {
+        // A chip is currently active — note it but still warn
+        freeHitNote = ' Note: you currently have a chip active.';
+      }
+
+      const teamNames = blankTeams.map((t) => t.name);
+
+      return {
+        id: 'freehit-blank-gameweek',
+        type: 'opportunity',
+        title: `Consider Free Hit for GW${blankGW} Blanks`,
+        message: `GW${blankGW} has ${blankCount} of ${totalTeams} teams without a fixture (${teamNames.join(', ')}). This is prime territory for your Free Hit chip — it lets you field a temporary 15-player squad for one week to maximise coverage of playing teams, then revert to your existing squad.${freeHitNote}`,
+        teams: blankTeams.map((t) => ({ id: t.id, name: t.name, shortName: t.short_name })),
+        planGameweek: blankGW,
+      };
+    },
+  },
+
+  // ── 10. Differential Pick Opportunity ────────────────────────────────────
   {
     id: 'differential-pick',
     priority: 3,

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -458,7 +458,7 @@ const RULES = [
         id: 'freehit-blank-gameweek',
         type: 'opportunity',
         title: `Consider Free Hit for GW${blankGW} Blanks`,
-        message: `GW${blankGW} has ${blankCount} of ${totalTeams} teams without a fixture (${teamNames.join(', ')}). This is prime territory for your Free Hit chip — it lets you field a temporary 15-player squad for one week to maximise coverage of playing teams, then revert to your existing squad.${freeHitNote}`,
+        message: `GW${blankGW} has ${blankCount} of ${totalTeams} teams without a fixture (${teamNames.join(', ')}). This is prime territory for your Free Hit chip.${freeHitNote}`,
         teams: blankTeams.map((t) => ({ id: t.id, name: t.name, shortName: t.short_name })),
         planGameweek: blankGW,
       };

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -628,6 +628,265 @@ const RULES = [
       };
     },
   },
+
+  // ── 12. Triple Captain Suggestion ────────────────────────────────────────
+  {
+    id: 'triple-captain',
+    priority: 1,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { squadPicks, squadPlayers, fixtures, targetGW } = ctx;
+      if (!squadPicks || !squadPlayers) return null;
+
+      // Only fire when the next GW is a DGW
+      const dgwGW = targetGW + 1;
+      if (dgwGW > 38) return null;
+
+      const dgwTeamFixtureCount = {};
+      fixtures
+        .filter((f) => f.event === dgwGW)
+        .forEach((f) => {
+          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
+          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
+        });
+      const dgwTeamIds = new Set(
+        Object.entries(dgwTeamFixtureCount)
+          .filter(([, count]) => count >= 2)
+          .map(([id]) => parseInt(id, 10)),
+      );
+      if (dgwTeamIds.size === 0) return null;
+
+      // Best DGW player in the squad (all 15) by predicted points
+      const dgwSquadPlayers = squadPlayers.filter((p) => dgwTeamIds.has(p.team));
+      if (dgwSquadPlayers.length === 0) return null;
+
+      const bestTc = dgwSquadPlayers
+        .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))[0];
+
+      const captainPick = squadPicks.picks.find((p) => p.is_captain);
+      const captain = captainPick ? squadPlayers.find((p) => p.id === captainPick.element) : null;
+      const captainPts = captain ? toFloat(captain.predicted_points || captain.ep_next) : 0;
+      const tcPts = toFloat(bestTc.predicted_points || bestTc.ep_next);
+
+      // TC earns pts × 3 vs captain's pts × 2 — only worth flagging if gain is meaningful
+      const tcGain = tcPts * 3 - captainPts * 2;
+      if (tcGain < 4) return null;
+
+      const captainNote = captain && captain.id !== bestTc.id
+        ? ` vs your current captain ${captain.web_name} (${captainPts.toFixed(1)} pts × 2 = ${(captainPts * 2).toFixed(1)})`
+        : '';
+
+      return {
+        id: 'triple-captain',
+        type: 'opportunity',
+        title: 'Triple Captain Opportunity',
+        message: `GW${dgwGW} is a double gameweek. ${bestTc.web_name} is your highest-scoring DGW player — predicted ${tcPts.toFixed(1)} pts × 3 = ${(tcPts * 3).toFixed(1)} pts with TC${captainNote}. Consider using your Triple Captain chip if unused.`,
+        players: [{ id: bestTc.id, name: bestTc.web_name, predictedPoints: tcPts }],
+      };
+    },
+  },
+
+  // ── 13. Bench Boost Suggestion ────────────────────────────────────────────
+  {
+    id: 'bench-boost',
+    priority: 1,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { squadPicks, squadPlayers, fixtures, targetGW } = ctx;
+      if (!squadPicks || !squadPlayers) return null;
+
+      // Only fire when the next GW is a DGW
+      const dgwGW = targetGW + 1;
+      if (dgwGW > 38) return null;
+
+      const dgwTeamFixtureCount = {};
+      fixtures
+        .filter((f) => f.event === dgwGW)
+        .forEach((f) => {
+          dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
+          dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
+        });
+      const dgwTeamIds = new Set(
+        Object.entries(dgwTeamFixtureCount)
+          .filter(([, count]) => count >= 2)
+          .map(([id]) => parseInt(id, 10)),
+      );
+      if (dgwTeamIds.size === 0) return null;
+
+      // Bench = positions 12–15
+      const benchIds = new Set(
+        squadPicks.picks.filter((p) => p.position >= 12).map((p) => p.element),
+      );
+      const benchPlayers = squadPlayers.filter((p) => benchIds.has(p.id));
+      if (benchPlayers.length === 0) return null;
+
+      const benchWithFixtures = benchPlayers.filter((p) => dgwTeamIds.has(p.team));
+      const benchPts = benchPlayers.reduce(
+        (sum, p) => sum + toFloat(p.predicted_points || p.ep_next),
+        0,
+      );
+
+      // Only suggest BB if bench predicted total is meaningful (>= 12 pts)
+      if (benchPts < 12) return null;
+
+      const dgwNote = benchWithFixtures.length > 0
+        ? ` ${benchWithFixtures.map((p) => p.web_name).join(', ')} ${benchWithFixtures.length === 1 ? 'has' : 'have'} a double gameweek.`
+        : '';
+
+      return {
+        id: 'bench-boost',
+        type: 'opportunity',
+        title: 'Bench Boost Opportunity',
+        message: `Your bench is predicted to score ${benchPts.toFixed(1)} pts in GW${dgwGW}.${dgwNote} If unused, your Bench Boost chip could be well-timed here.`,
+        players: benchPlayers
+          .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
+          .map((p) => ({
+            id: p.id,
+            name: p.web_name,
+            predictedPoints: toFloat(p.predicted_points || p.ep_next),
+          })),
+      };
+    },
+  },
+
+  // ── 14. Wildcard Timing ───────────────────────────────────────────────────
+  {
+    id: 'wildcard-timing',
+    priority: 2,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { squadPlayers, playerFixtureRun } = ctx;
+      if (!squadPlayers || !playerFixtureRun) return null;
+
+      const LOOKAHEAD = 3;
+      const DIFFICULTY_THRESHOLD = 3.8;
+      const MIN_INJURED = 2;
+
+      // Count injured/doubtful starters
+      const atRisk = squadPlayers.filter((p) => {
+        const chance = p.chance_of_playing_next_round;
+        return (chance !== null && chance !== undefined && chance < 75) ||
+          (p.status && p.status !== 'a');
+      });
+
+      if (atRisk.length < MIN_INJURED) return null;
+
+      // Count players with a rough fixture run
+      const toughRun = squadPlayers.filter((p) => {
+        const run = (playerFixtureRun[p.id] || []).slice(0, LOOKAHEAD);
+        const withFixtures = run.filter((gw) => gw.hasFixture);
+        if (withFixtures.length === 0) return false;
+        const avg = withFixtures.reduce((s, gw) => s + gw.difficulty, 0) / withFixtures.length;
+        return avg >= DIFFICULTY_THRESHOLD;
+      });
+
+      if (toughRun.length < 2) return null;
+
+      return {
+        id: 'wildcard-timing',
+        type: 'warning',
+        title: 'Wildcard Timing?',
+        message: `You have ${atRisk.length} player${atRisk.length > 1 ? 's' : ''} injured or doubtful (${atRisk.map((p) => p.web_name).join(', ')}) and ${toughRun.length} player${toughRun.length > 1 ? 's' : ''} with a tough ${LOOKAHEAD}-GW run. It may be worth considering your Wildcard to reshape the squad.`,
+        players: atRisk.map((p) => ({
+          id: p.id,
+          name: p.web_name,
+          chance: p.chance_of_playing_next_round,
+          news: p.news,
+        })),
+      };
+    },
+  },
+
+  // ── 15. Owned Premium Being Sold — Ownership Erosion Alert ───────────────
+  {
+    id: 'ownership-erosion',
+    priority: 2,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { squadPlayers } = ctx;
+      if (!squadPlayers) return null;
+
+      const atRisk = squadPlayers.filter((p) => {
+        const ownership = toFloat(p.selected_by_percent);
+        const netTransfers = (p.transfers_in_event || 0) - (p.transfers_out_event || 0);
+        const totalVolume = (p.transfers_in_event || 0) + (p.transfers_out_event || 0);
+        return ownership >= 30 && netTransfers < -80000 && totalVolume >= 50000;
+      });
+
+      if (atRisk.length === 0) return null;
+
+      const descriptions = atRisk.map((p) => {
+        const netOut = Math.abs((p.transfers_in_event || 0) - (p.transfers_out_event || 0));
+        return `${p.web_name} (${toFloat(p.selected_by_percent).toFixed(1)}% owned, ~${(netOut / 1000).toFixed(0)}k net sells this GW)`;
+      });
+
+      return {
+        id: 'ownership-erosion',
+        type: 'warning',
+        title: 'Popular Players Being Sold',
+        message: `${descriptions.join('\n')}\nManagers are moving away from ${atRisk.length === 1 ? 'this player' : 'these players'} — holding could cost you rank if the trend continues.`,
+        players: atRisk.map((p) => ({
+          id: p.id,
+          name: p.web_name,
+          ownership: toFloat(p.selected_by_percent),
+          trend: 'falling',
+        })),
+      };
+    },
+  },
+
+  // ── 16. In-Form Players Outside Your Squad ────────────────────────────────
+  {
+    id: 'form-alert',
+    priority: 2,
+    enabled: true,
+    requiresSquad: true,
+    generate(ctx) {
+      const { allPlayers, squadPlayers, playerFixtureRun, targetGW } = ctx;
+      if (!squadPlayers || !playerFixtureRun) return null;
+
+      const FORM_THRESHOLD = 6.0;
+      const squadIds = new Set(squadPlayers.map((p) => p.id));
+
+      const candidates = allPlayers
+        .filter((p) => !squadIds.has(p.id))
+        .filter((p) => {
+          const form = toFloat(p.form);
+          if (form < FORM_THRESHOLD) return false;
+
+          // Must have a fixture in targetGW with decent difficulty
+          const run = (playerFixtureRun[p.id] || []).find((gw) => gw.gameweek === targetGW);
+          return run && run.hasFixture && run.difficulty <= 3;
+        })
+        .sort((a, b) => toFloat(b.form) - toFloat(a.form))
+        .slice(0, 3);
+
+      if (candidates.length === 0) return null;
+
+      const best = candidates[0];
+      const form = toFloat(best.form).toFixed(1);
+      const price = (best.now_cost / 10).toFixed(1);
+      const ownership = toFloat(best.selected_by_percent).toFixed(1);
+
+      return {
+        id: 'form-alert',
+        type: 'opportunity',
+        title: 'In-Form Players to Consider',
+        message: `${best.web_name} (£${price}m, ${ownership}% owned) is in excellent form averaging ${form} pts/game with a good GW${targetGW} fixture. Not in your squad.`,
+        players: candidates.map((p) => ({
+          id: p.id,
+          name: p.web_name,
+          price: p.now_cost / 10,
+          ownership: toFloat(p.selected_by_percent),
+          form: toFloat(p.form),
+        })),
+      };
+    },
+  },
 ];
 
 module.exports = { RULES };

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -348,7 +348,7 @@ const RULES = [
     enabled: true,
     requiresSquad: true,
     generate(ctx) {
-      const { currentGWPicks, prevGWPicks, targetGW } = ctx;
+      const { currentGWPicks, prevGWPicks, targetGW, fixtures, bootstrap, allPlayers, squadPlayers } = ctx;
       if (!currentGWPicks || !prevGWPicks) return null;
 
       // If transfers already made this GW, no need for the hint
@@ -362,11 +362,61 @@ const RULES = [
 
       if (minFreeTransfers < 2) return null;
 
+      // Check if the GW two ahead is a heavy blank (Free Hit territory)
+      const blankGW = targetGW + 2;
+      let contextMsg = `Use ${minFreeTransfers > 1 ? 'some' : 'it'} to strengthen your squad — unused free transfers stack up to a cap of 5.`;
+
+      if (blankGW <= 38) {
+        const teamsWithFixture = new Set(
+          fixtures
+            .filter((f) => f.event === blankGW)
+            .flatMap((f) => [f.team_h, f.team_a]),
+        );
+        const blankTeamIds = new Set(
+          bootstrap.teams.filter((t) => !teamsWithFixture.has(t.id)).map((t) => t.id),
+        );
+
+        if (blankTeamIds.size >= 6) {
+          // Free Hit blank GW scenario — suggest holding transfers and targeting DGW players instead
+          const dgwGW = targetGW + 1;
+          const dgwTeamFixtureCount = {};
+          fixtures
+            .filter((f) => f.event === dgwGW)
+            .forEach((f) => {
+              dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
+              dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
+            });
+          const dgwTeamIds = new Set(
+            Object.entries(dgwTeamFixtureCount)
+              .filter(([, count]) => count >= 2)
+              .map(([id]) => parseInt(id, 10)),
+          );
+
+          if (dgwTeamIds.size > 0) {
+            // Find best DGW players not yet in squad
+            const squadIds = new Set((squadPlayers || []).map((p) => p.id));
+            const dgwTargets = allPlayers
+              .filter((p) => dgwTeamIds.has(p.team) && !squadIds.has(p.id))
+              .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
+              .slice(0, 3);
+
+            if (dgwTargets.length > 0) {
+              const names = dgwTargets.map((p) => `${p.web_name} (£${(p.now_cost / 10).toFixed(1)}m)`).join(', ');
+              contextMsg = `With GW${blankGW} shaping up as a Free Hit gameweek, consider using ${minFreeTransfers > 1 ? 'your transfers' : 'your transfer'} to bring in double gameweek players for GW${dgwGW} now. Top targets: ${names}.`;
+            } else {
+              contextMsg = `With GW${blankGW} shaping up as a Free Hit gameweek, consider using ${minFreeTransfers > 1 ? 'your transfers' : 'your transfer'} to target double gameweek players for GW${dgwGW}.`;
+            }
+          } else {
+            contextMsg = `With GW${blankGW} shaping up as a Free Hit gameweek, consider saving ${minFreeTransfers > 1 ? 'your transfers' : 'your transfer'} for players who have fixtures that week.`;
+          }
+        }
+      }
+
       return {
         id: 'free-transfers',
         type: 'info',
         title: 'Free Transfers Available',
-        message: `You have at least ${minFreeTransfers} free transfer${minFreeTransfers > 1 ? 's' : ''} available in GW${targetGW}. Use ${minFreeTransfers > 1 ? 'some' : 'it'} to strengthen your squad — unused free transfers stack up to a cap of 5.`,
+        message: `You have at least ${minFreeTransfers} free transfer${minFreeTransfers > 1 ? 's' : ''} available in GW${targetGW}. ${contextMsg}`,
       };
     },
   },
@@ -413,7 +463,7 @@ const RULES = [
         id: 'upcoming-double-gameweek',
         type: 'opportunity',
         title: `Plan Ahead: Double Gameweek ${planGW}`,
-        message: `GW${planGW} (next gameweek after this one) is a double gameweek for ${teamNames.join(', ')}. Use your free transfers this week to target players from ${dgwTeams.length === 1 ? 'this team' : 'these teams'} so you're set up to maximise points.${squadNote}`,
+        message: `GW${planGW} is a double gameweek for ${teamNames.join(', ')}. Use your free transfers this week to target players from ${dgwTeams.length === 1 ? 'this team' : 'these teams'} so you're set up to maximise points.${squadNote}`,
         teams: dgwTeams.map((t) => ({ id: t.id, name: t.name, shortName: t.short_name })),
         planGameweek: planGW,
       };
@@ -476,18 +526,66 @@ const RULES = [
     },
   },
 
-  // ── 10. Differential Pick Opportunity ────────────────────────────────────
+  // ── 10. Differential / DGW Pick Opportunity ─────────────────────────────
   {
     id: 'differential-pick',
     priority: 3,
     enabled: true,
     requiresSquad: true,
     generate(ctx) {
-      const { allPlayers, squadPlayers, targetGW } = ctx;
+      const { allPlayers, squadPlayers, targetGW, fixtures } = ctx;
       if (!squadPlayers) return null;
 
       const squadIds = new Set(squadPlayers.map((p) => p.id));
 
+      // Check if the next GW (targetGW + 1) is a DGW
+      const dgwGW = targetGW + 1;
+      const dgwTeamFixtureCount = {};
+      if (dgwGW <= 38) {
+        fixtures
+          .filter((f) => f.event === dgwGW)
+          .forEach((f) => {
+            dgwTeamFixtureCount[f.team_h] = (dgwTeamFixtureCount[f.team_h] || 0) + 1;
+            dgwTeamFixtureCount[f.team_a] = (dgwTeamFixtureCount[f.team_a] || 0) + 1;
+          });
+      }
+      const dgwTeamIds = new Set(
+        Object.entries(dgwTeamFixtureCount)
+          .filter(([, count]) => count >= 2)
+          .map(([id]) => parseInt(id, 10)),
+      );
+      const hasDGW = dgwTeamIds.size > 0;
+
+      if (hasDGW) {
+        // Prioritise: DGW players not in squad, ranked by predicted points, ownership < 25%
+        const dgwCandidates = allPlayers
+          .filter((p) => !squadIds.has(p.id) && dgwTeamIds.has(p.team))
+          .filter((p) => toFloat(p.selected_by_percent) < 25)
+          .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
+          .slice(0, 3);
+
+        if (dgwCandidates.length > 0) {
+          const best = dgwCandidates[0];
+          const ownership = toFloat(best.selected_by_percent).toFixed(1);
+          const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
+          const price = (best.now_cost / 10).toFixed(1);
+          return {
+            id: 'differential-pick',
+            type: 'opportunity',
+            title: `DGW${dgwGW} Differential Targets`,
+            message: `${best.web_name} (£${price}m, ${ownership}% owned) is a standout differential for GW${dgwGW}'s double gameweek — predicted ${pts} pts with two fixtures. Low ownership means big rank gains if they deliver.`,
+            players: dgwCandidates.map((p) => ({
+              id: p.id,
+              name: p.web_name,
+              price: p.now_cost / 10,
+              ownership: toFloat(p.selected_by_percent),
+              predictedPoints: toFloat(p.predicted_points || p.ep_next),
+            })),
+          };
+        }
+      }
+
+      // Fallback: general differential (low ownership, high ICT, good predicted points)
       const candidates = allPlayers
         .filter((p) => !squadIds.has(p.id))
         .filter((p) => {

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -570,7 +570,7 @@ const RULES = [
       return {
         id: 'differential-pick-dgw',
         type: 'opportunity',
-        title: `Differential Transfer Targets`,
+        title: `Double Gameweek Transfer Targets`,
         message: `${best.web_name} (£${price}m, ${ownership}% owned) is a standout differential for GW${dgwGW}'s double gameweek — predicted ${pts} pts with two fixtures.`,
         players: candidates.map((p) => ({
           id: p.id,
@@ -615,7 +615,7 @@ const RULES = [
       return {
         id: 'differential-pick-general',
         type: 'opportunity',
-        title: 'Transfer Targets',
+        title: 'Differential Transfer Targets',
         message: `${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts in GW${targetGW} with a strong ICT index.`,
         players: candidates.map((p) => ({
           id: p.id,

--- a/backend/utils/assistantRules.js
+++ b/backend/utils/assistantRules.js
@@ -556,37 +556,17 @@ const RULES = [
       );
       const hasDGW = dgwTeamIds.size > 0;
 
-      if (hasDGW) {
-        // Prioritise: DGW players not in squad, ranked by predicted points, ownership < 25%
-        const dgwCandidates = allPlayers
-          .filter((p) => !squadIds.has(p.id) && dgwTeamIds.has(p.team))
-          .filter((p) => toFloat(p.selected_by_percent) < 25)
-          .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
-          .slice(0, 3);
+      // DGW differentials: not in squad, from DGW teams, ownership < 25%, best predicted pts
+      const dgwCandidates = hasDGW
+        ? allPlayers
+            .filter((p) => !squadIds.has(p.id) && dgwTeamIds.has(p.team))
+            .filter((p) => toFloat(p.selected_by_percent) < 25)
+            .sort((a, b) => toFloat(b.predicted_points || b.ep_next) - toFloat(a.predicted_points || a.ep_next))
+            .slice(0, 3)
+        : [];
 
-        if (dgwCandidates.length > 0) {
-          const best = dgwCandidates[0];
-          const ownership = toFloat(best.selected_by_percent).toFixed(1);
-          const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
-          const price = (best.now_cost / 10).toFixed(1);
-          return {
-            id: 'differential-pick',
-            type: 'opportunity',
-            title: `DGW${dgwGW} Differential Targets`,
-            message: `${best.web_name} (£${price}m, ${ownership}% owned) is a standout differential for GW${dgwGW}'s double gameweek — predicted ${pts} pts with two fixtures. Low ownership means big rank gains if they deliver.`,
-            players: dgwCandidates.map((p) => ({
-              id: p.id,
-              name: p.web_name,
-              price: p.now_cost / 10,
-              ownership: toFloat(p.selected_by_percent),
-              predictedPoints: toFloat(p.predicted_points || p.ep_next),
-            })),
-          };
-        }
-      }
-
-      // Fallback: general differential (low ownership, high ICT, good predicted points)
-      const candidates = allPlayers
+      // General differentials: not in squad, low ownership, high ICT, good predicted pts
+      const generalCandidates = allPlayers
         .filter((p) => !squadIds.has(p.id))
         .filter((p) => {
           const ownership = toFloat(p.selected_by_percent);
@@ -597,26 +577,49 @@ const RULES = [
         .sort((a, b) => toFloat(b.ict_index) - toFloat(a.ict_index))
         .slice(0, 3);
 
-      if (candidates.length === 0) return null;
+      if (dgwCandidates.length === 0 && generalCandidates.length === 0) return null;
 
-      const best = candidates[0];
-      const ownership = toFloat(best.selected_by_percent).toFixed(1);
-      const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
-      const price = (best.now_cost / 10).toFixed(1);
+      const messageParts = [];
+
+      if (dgwCandidates.length > 0) {
+        const best = dgwCandidates[0];
+        const ownership = toFloat(best.selected_by_percent).toFixed(1);
+        const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
+        const price = (best.now_cost / 10).toFixed(1);
+        messageParts.push(`DGW${dgwGW} differential: ${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts with two fixtures.`);
+      }
+
+      if (generalCandidates.length > 0) {
+        const best = generalCandidates[0];
+        const ownership = toFloat(best.selected_by_percent).toFixed(1);
+        const pts = toFloat(best.predicted_points || best.ep_next).toFixed(1);
+        const price = (best.now_cost / 10).toFixed(1);
+        messageParts.push(`General differential: ${best.web_name} (£${price}m, ${ownership}% owned) — predicted ${pts} pts with a strong ICT index.`);
+      }
 
       return {
         id: 'differential-pick',
         type: 'opportunity',
-        title: 'Differential Opportunity',
-        message: `${best.web_name} (£${price}m) is owned by only ${ownership}% of managers but is predicted to score ${pts} pts in GW${targetGW} with a strong ICT index. A well-timed differential pick.`,
-        players: candidates.map((p) => ({
-          id: p.id,
-          name: p.web_name,
-          price: p.now_cost / 10,
-          ownership: toFloat(p.selected_by_percent),
-          predictedPoints: toFloat(p.predicted_points || p.ep_next),
-          ictIndex: toFloat(p.ict_index),
-        })),
+        title: hasDGW ? `Differential Targets (incl. DGW${dgwGW})` : 'Differential Opportunity',
+        message: messageParts.join('\n'),
+        players: [
+          ...dgwCandidates.map((p) => ({
+            id: p.id,
+            name: p.web_name,
+            price: p.now_cost / 10,
+            ownership: toFloat(p.selected_by_percent),
+            predictedPoints: toFloat(p.predicted_points || p.ep_next),
+            tag: `DGW${dgwGW}`,
+          })),
+          ...generalCandidates.map((p) => ({
+            id: p.id,
+            name: p.web_name,
+            price: p.now_cost / 10,
+            ownership: toFloat(p.selected_by_percent),
+            predictedPoints: toFloat(p.predicted_points || p.ep_next),
+            ictIndex: toFloat(p.ict_index),
+          })),
+        ],
       };
     },
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -366,7 +366,7 @@ const App = () => {
               viewingOpponentId={ viewingOpponentId }
               currentEntryId={ currentEntryId }
               userEntryId={ userEntryId }
-              gameweekDeadline={ gameweekInfo?.data?.deadline_time || null }
+              gameweekDeadline={ gameweekInfo?.data?.deadline_time }
             />
           </Box>
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -366,6 +366,7 @@ const App = () => {
               viewingOpponentId={ viewingOpponentId }
               currentEntryId={ currentEntryId }
               userEntryId={ userEntryId }
+              gameweekDeadline={ gameweekInfo?.data?.deadline_time || null }
             />
           </Box>
 

--- a/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
+++ b/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
@@ -21,11 +21,10 @@ function borderColor(theme, priority) {
   return theme.palette.text.disabled;
 }
 
-// Players with a trend field get a directional arrow label suffix; tag field gets a prefix
+// Players with a trend field get a directional arrow label suffix
 function playerLabel(p) {
-  const prefix = p.tag ? `[${p.tag}] ` : '';
-  if (!p.trend) return `${prefix}${p.name}`;
-  return p.trend === 'rising' ? `${prefix}${p.name} ▲` : `${prefix}${p.name} ▼`;
+  if (!p.trend) return p.name;
+  return p.trend === 'rising' ? `${p.name} ▲` : `${p.name} ▼`;
 }
 
 const AssistantManagerPanel = ({ entryId, currentGameweek }) => {

--- a/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
+++ b/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
@@ -21,10 +21,11 @@ function borderColor(theme, priority) {
   return theme.palette.text.disabled;
 }
 
-// Players with a trend field get a directional arrow label suffix
+// Players with a trend field get a directional arrow label suffix; tag field gets a prefix
 function playerLabel(p) {
-  if (!p.trend) return p.name;
-  return p.trend === 'rising' ? `${p.name} ▲` : `${p.name} ▼`;
+  const prefix = p.tag ? `[${p.tag}] ` : '';
+  if (!p.trend) return `${prefix}${p.name}`;
+  return p.trend === 'rising' ? `${prefix}${p.name} ▲` : `${prefix}${p.name} ▼`;
 }
 
 const AssistantManagerPanel = ({ entryId, currentGameweek }) => {

--- a/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
+++ b/frontend/src/components/AssistantManagerPanel/AssistantManagerPanel.jsx
@@ -138,6 +138,23 @@ const AssistantManagerPanel = ({ entryId, currentGameweek }) => {
                   )) }
                 </Box>
               ) }
+
+              { /* Team chips */ }
+              { hint.teams && hint.teams.length > 0 && (
+                <Box
+                  sx={ { display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.75 } }
+                >
+                  { hint.teams.map((t) => (
+                    <Chip
+                      key={ t.id }
+                      label={ t.shortName ?? t.name }
+                      size='small'
+                      variant='outlined'
+                      sx={ { height: 20, fontSize: '0.7rem' } }
+                    />
+                  )) }
+                </Box>
+              ) }
             </Box>
           )) }
         </Box>

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -23,11 +23,38 @@ const formatDateHeader = (date) =>
 const formatTime = (date) =>
   date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
 
-const FixturesPanel = ({ gameweek }) => {
+const getDeadlinePill = (deadline, theme) => {
+  if (!deadline) return null;
+  const now = new Date();
+  const dl = new Date(deadline);
+  if (dl <= now) return null; // deadline passed — don't show
+  const hoursAway = (dl - now) / (1000 * 60 * 60);
+
+  let bg, color;
+  if (hoursAway < 24) {
+    bg = theme.palette.error.main;
+    color = theme.palette.error.contrastText;
+  } else if (hoursAway < 48) {
+    bg = theme.palette.warning.main;
+    color = theme.palette.warning.contrastText;
+  } else {
+    bg = theme.palette.success.main;
+    color = theme.palette.success.contrastText;
+  }
+
+  const formatted = dl.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })
+    + ' ' + dl.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+  return { bg, color, label: `Deadline: ${formatted}` };
+};
+
+const FixturesPanel = ({ gameweek, deadline }) => {
   const theme = useTheme();
   const [fixtures, setFixtures] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const deadlinePill = getDeadlinePill(deadline, theme);
 
   const teamNameSx = { flex: 1, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 
@@ -55,9 +82,28 @@ const FixturesPanel = ({ gameweek }) => {
 
   return (
     <Box>
-      <Typography variant='h6' sx={ { mb: 1, fontWeight: 600 } }>
-        GW{ gameweek } Fixtures
-      </Typography>
+      <Box sx={ { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1, mb: 1 } }>
+        <Typography variant='h6' sx={ { fontWeight: 600 } }>
+          GW{ gameweek } Fixtures
+        </Typography>
+        { deadlinePill && (
+          <Box
+            sx={ {
+              bgcolor: deadlinePill.bg,
+              color: deadlinePill.color,
+              borderRadius: '10px',
+              px: 1,
+              py: 0.25,
+              fontSize: '0.65rem',
+              fontWeight: 700,
+              whiteSpace: 'nowrap',
+              lineHeight: 1.4,
+            } }
+          >
+            { deadlinePill.label }
+          </Box>
+        ) }
+      </Box>
 
       { loading && (
         <Box sx={ { display: 'flex', justifyContent: 'center', py: 2 } }>
@@ -151,6 +197,7 @@ const FixturesPanel = ({ gameweek }) => {
 
 FixturesPanel.propTypes = {
   gameweek: PropTypes.number,
+  deadline: PropTypes.string,
 };
 
 export default FixturesPanel;

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -27,6 +27,7 @@ const getDeadlinePill = (deadline, theme) => {
   if (!deadline) return null;
   const now = new Date();
   const dl = new Date(deadline);
+  if (!Number.isFinite(dl.getTime())) return null;
   if (dl <= now) return null; // deadline passed — don't show
   const hoursAway = (dl - now) / (1000 * 60 * 60);
 

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -16,6 +16,7 @@ const RightPanel = ({
   onViewTeam,
   currentGameweek,
   selectedGameweek,
+  gameweekDeadline,
 }) => {
   const theme = useTheme();
   const displayGameweek = selectedGameweek || currentGameweek;
@@ -56,7 +57,7 @@ const RightPanel = ({
         <>
           { entryId && <Divider sx={ { my: 1 } } /> }
           <Box sx={ { p: 2 } }>
-            <FixturesPanel gameweek={ displayGameweek } />
+            <FixturesPanel gameweek={ displayGameweek } deadline={ gameweekDeadline } />
           </Box>
         </>
       ) }
@@ -74,6 +75,7 @@ RightPanel.propTypes = {
   onViewTeam: PropTypes.func,
   currentGameweek: PropTypes.number,
   selectedGameweek: PropTypes.number,
+  gameweekDeadline: PropTypes.string,
 };
 
 export default RightPanel;

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -46,8 +46,7 @@ const TeamActivityPanel = ({
       });
   }, [entryId]);
 
-  if (!entryId) return null;
-  if (loading) return <Paper sx={ { p: 2 } }><Typography>Loading...</Typography></Paper>;
+  if (entryId && loading) return <Paper sx={ { p: 2 } }><Typography>Loading...</Typography></Paper>;
 
   const formatNumber = n => (n == null ? 'N/A' : n.toLocaleString());
   const formatCurrency = n => (n == null ? 'N/A' : `£${(n / 10).toFixed(1)}m`);
@@ -139,6 +138,7 @@ const TeamActivityPanel = ({
       ) }
 
       { /* Recent Performance - Middle Section */ }
+      { entryId && (
       <Paper
         sx={ {
           backgroundColor: theme.palette.background.paper,
@@ -197,6 +197,7 @@ const TeamActivityPanel = ({
           </Box>
         ) }
       </Paper>
+      ) }
 
       { /* Recommended Transfers - Bottom Section */ }
       { currentEntryId && !viewingOpponentId && currentGameweek && (

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -77,7 +77,7 @@ const TeamActivityPanel = ({
       } }
     >
       { /* Team Stats - Top Section */ }
-      { profile && (
+      { entryId && profile && (
         <Paper
           sx={ {
             backgroundColor: theme.palette.background.paper,


### PR DESCRIPTION
This pull request adds two new planning rules to the `assistantRules.js` file to help users better prepare for upcoming double and blank gameweeks in fantasy football. These rules provide proactive advice for squad management, such as targeting teams with upcoming double gameweeks and considering the use of the Free Hit chip when many teams have no fixtures.

**New planning and chip strategy rules:**

* Adds a rule (`upcoming-double-gameweek`) that detects if the next gameweek after the current one is a double gameweek for any teams, and advises users to target players from those teams with their free transfers. The rule also provides a note if the user's squad already contains relevant players.
* Adds a rule (`freehit-blank-gameweek`) that identifies if two weeks ahead there is a blank gameweek (six or more teams without a fixture), and suggests considering the Free Hit chip to maximize points. It also notes if a chip is already active.