### PR TITLE
Enhance transfer logic and player display for accurate pricing

### DIFF
--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -478,10 +478,40 @@ const getUserTeamForEntry = async (req, res) => {
       return res.status(500).json({ error: 'Error fetching team picks' });
     }
 
-    let players = bootstrap.elements.map((p) => ({
-      ...p,
-      ep_next: parseFloat(p.ep_next) || 0,
-    }));
+    // Fetch transfer history to calculate accurate selling prices.
+    // FPL rule: selling_price = purchase_price + floor((now_cost - purchase_price) / 2)
+    // If price dropped below purchase: selling_price = now_cost (full loss, no profit share).
+    // For original squad members (never transferred): purchase_price = now_cost - cost_change_start.
+    let purchasePriceMap = {};
+    try {
+      const transfers = await dataProvider.fetchEntryTransfers(entryId);
+      // Sort ascending by event so later transfers overwrite earlier ones —
+      // handles sell-and-rebuy: the most recent transfer-in cost wins.
+      const sorted = [...transfers].sort((a, b) => {
+        if (a.event !== b.event) return a.event - b.event;
+        return (a.time ?? '').localeCompare(b.time ?? '');
+      });
+      for (const t of sorted) {
+        purchasePriceMap[t.element_in] = t.element_in_cost;
+      }
+    } catch {
+      // Non-fatal — will fall back to start-of-season price for all players
+    }
+
+    let players = bootstrap.elements.map((p) => {
+      // Determine purchase price: transfer record takes priority; otherwise use
+      // the season-start price derived from cost_change_start.
+      const purchasePrice = purchasePriceMap[p.id] ?? (p.now_cost - (p.cost_change_start ?? 0));
+      const sellingPrice = p.now_cost >= purchasePrice
+        ? purchasePrice + Math.floor((p.now_cost - purchasePrice) / 2)
+        : p.now_cost;
+      return {
+        ...p,
+        ep_next: parseFloat(p.ep_next) || 0,
+        purchase_price: purchasePrice,
+        selling_price: sellingPrice,
+      };
+    });
 
     const isPastGameweek = !!(targetEventData && targetEventData.finished);
     const isActiveGameweek = !!(targetEventData && targetEventData.is_current && !targetEventData.finished);
@@ -544,6 +574,7 @@ const getUserTeamForEntry = async (req, res) => {
       isFutureGameweek,
       gameweekData: targetEventData,
       freeTransfers,
+      bank: picksData.entry_history?.bank ?? null,
     });
   } catch (error) {
     console.error('Error building user team:', error);

--- a/backend/entities/Player.js
+++ b/backend/entities/Player.js
@@ -39,8 +39,8 @@ class Player {
     // they fall back to now_cost when building the highest-predicted team where
     // no user-specific purchase history is available.
     this.nowCost         = raw.now_cost;
-    this.purchasePrice   = enrichment.purchasePrice ?? raw.now_cost;
-    this.sellingPrice    = enrichment.sellingPrice  ?? raw.now_cost;
+    this.purchasePrice   = enrichment.purchasePrice ?? raw.purchase_price ?? raw.now_cost;
+    this.sellingPrice    = enrichment.sellingPrice  ?? raw.selling_price  ?? raw.now_cost;
 
     // Availability / injury status
     this.status                    = raw.status;

--- a/backend/models/dataProvider.js
+++ b/backend/models/dataProvider.js
@@ -176,6 +176,23 @@ const fetchHistory = async (entryId) => {
 };
 
 /**
+ * Fetch all transfers made by an entry (team)
+ * @param {number|string} entryId - FPL entry/team ID
+ * @returns {Promise<Array>} - Array of transfer objects { element_in, element_in_cost, element_out, element_out_cost, entry, event, time }
+ */
+const fetchEntryTransfers = async (entryId) => {
+  const validatedEntryId = validateEntryId(entryId);
+  if (USE_FPL_API) {
+    const url = `${FPL_API_BASE}/entry/${validatedEntryId}/transfers/`;
+    const response = await axios.get(url);
+    return response.data;
+  } else {
+    console.log(`[Mock Mode] Fetching transfers for entry ${validatedEntryId} from local data`);
+    return [];
+  }
+};
+
+/**
  * Fetch classic league standings
  * @param {number|string} leagueId - FPL classic league ID
  * @param {number} [page=1] - Page number for standings pagination
@@ -204,6 +221,7 @@ module.exports = {
   fetchLiveGameweek,
   fetchEntry,
   fetchHistory,
+  fetchEntryTransfers,
   fetchLeagueStandings,
   USE_FPL_API
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,6 +62,7 @@ const App = () => {
     setCaptain,
     autoPickLineup,
     freeTransfers,
+    bank,
   } = useTeamData(
     currentEntryId,
     teamView === TEAM_VIEW.HIGHEST,
@@ -219,6 +220,37 @@ const App = () => {
   // Planned transfers shown to pitch/bench components — suppressed for locked GWs
   // so stale planned-transfer badges don't render on top of actual picks data.
   const displayPlannedTransfers = isLockedGameweek ? undefined : plannedTransfers;
+
+  // Bank balance adjusted for planned transfers targeting the viewed GW.
+  // null = not applicable (highest predicted team, opponent view, or no bank data).
+  // When viewing a future GW with planned transfers, projects the bank balance
+  // after applying the cumulative cost delta of those transfers.
+  const displayBank = useMemo(() => {
+    if (isHighestPredictedTeam || viewingOpponentId || bank == null) return null;
+    if (!gameweekInfo?.isFuture) return null; // Only show for future GWs
+    const viewedGW = gameweekInfo?.selected ?? currentGameweek;
+    // Apply cumulative transfer cost deltas up to and including viewedGW.
+    const delta = plannedTransfers
+      .filter(t => t.gameweek <= viewedGW)
+      .reduce((sum, t) => {
+        const sellPrice = t.playerOut.sellingPrice ?? t.playerOut.nowCost ?? 0;
+        const buyPrice  = t.playerIn.nowCost ?? 0;
+        return sum + sellPrice - buyPrice;
+      }, 0);
+    return bank + delta;
+  }, [isHighestPredictedTeam, viewingOpponentId, bank, gameweekInfo, currentGameweek, plannedTransfers]);
+
+  // Funds coming in (sum of selling prices) and going out (sum of buying prices)
+  // for planned transfers scheduled for the viewed GW specifically.
+  const displayTransferFunds = useMemo(() => {
+    if (!gameweekInfo?.isFuture || isHighestPredictedTeam || viewingOpponentId) return null;
+    const viewedGW = gameweekInfo?.selected ?? currentGameweek;
+    const gwTransfers = plannedTransfers.filter(t => t.gameweek === viewedGW);
+    if (gwTransfers.length === 0) return null;
+    const fundsIn  = gwTransfers.reduce((s, t) => s + (t.playerOut.sellingPrice ?? t.playerOut.nowCost ?? 0), 0);
+    const fundsOut = gwTransfers.reduce((s, t) => s + (t.playerIn.nowCost ?? 0), 0);
+    return { fundsIn, fundsOut };
+  }, [gameweekInfo, isHighestPredictedTeam, viewingOpponentId, currentGameweek, plannedTransfers]);
 
   // Captain's base points (before 2× multiplier) — used by Triple Captain chip
   const captainBasePoints = useMemo(() => {
@@ -449,7 +481,7 @@ const App = () => {
                 ) }
 
                 { /* Stats + controls grid */ }
-                <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: displayFreeTransfers != null ? '1fr 1fr 1fr 1fr' : '1fr 1fr 1fr', textAlign: 'center', rowGap: 0.75 } }>
+                <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: displayFreeTransfers != null || displayBank != null ? `1fr 1fr${ displayFreeTransfers != null ? ' 1fr' : '' }${ displayBank != null ? ' 1fr' : '' } 1fr` : '1fr 1fr 1fr', textAlign: 'center', rowGap: 0.75 } }>
                   { /* Row 1 — labels */ }
                   <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
                     Total Points
@@ -460,6 +492,11 @@ const App = () => {
                   { displayFreeTransfers != null && (
                     <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
                       Free Transfers
+                    </Typography>
+                  ) }
+                  { displayBank != null && (
+                    <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
+                      In the Bank
                     </Typography>
                   ) }
                   <Box sx={ { display: 'flex', justifyContent: 'center' } }>
@@ -503,6 +540,18 @@ const App = () => {
                             </Typography>
                           ) }
                         </>
+                      ) }
+                    </Box>
+                  ) }
+                  { displayBank != null && (
+                    <Box sx={ { display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' } }>
+                      <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2, color: displayBank >= 0 ? 'success.main' : 'error.main' } }>
+                        £{ (displayBank / 10).toFixed(1) }m
+                      </Typography>
+                      { displayTransferFunds && (
+                        <Typography variant='caption' sx={ { color: 'text.secondary', fontWeight: 500, lineHeight: 1, whiteSpace: 'nowrap' } }>
+                          in £{ (displayTransferFunds.fundsIn / 10).toFixed(1) }m · out £{ (displayTransferFunds.fundsOut / 10).toFixed(1) }m
+                        </Typography>
                       ) }
                     </Box>
                   ) }

--- a/frontend/src/components/PlayerCard/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard/PlayerCard.jsx
@@ -367,6 +367,25 @@ const PlayerCard = ({ player, isCaptain, team, allPlayers, onTransfer, showTrans
 
           </Grid>
         ) }
+
+        { /* Price tag — shown on future GW cards */ }
+        { isFutureGameweek && player.nowCost != null && (
+          <Box
+            sx={ {
+              mx: -0.5,
+              mb: -0.5,
+              mt: 0.5,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              textAlign: 'center',
+              py: '2px',
+            } }
+          >
+            <Typography variant='caption' sx={ { fontSize: '0.65rem', fontWeight: 600, color: 'text.secondary', letterSpacing: '0.3px' } }>
+              £{ ((player.sellingPrice ?? player.nowCost) / 10).toFixed(1) }m
+            </Typography>
+          </Box>
+        ) }
       </CardContent>
 
       { transferDialogOpen && (
@@ -416,6 +435,7 @@ PlayerCard.propTypes = {
     status: PropTypes.string,
     chanceOfPlayingNextRound: PropTypes.number,
     news: PropTypes.string,
+    nowCost: PropTypes.number,
   }).isRequired,
   isCaptain: PropTypes.bool,
   team: PropTypes.array,

--- a/frontend/src/components/TransferPlayer/TransferPlayer.jsx
+++ b/frontend/src/components/TransferPlayer/TransferPlayer.jsx
@@ -87,7 +87,10 @@ const TransferPlayer = ({ team, allPlayers, onTransfer, playerOut, open, onClose
                 <DialogContent>
                     { /* Player Out: fixed, not a dropdown */ }
                     <ListItem>
-                        <ListItemText primary={ playerOut.name } secondary={ { 1: 'Goalkeeper', 2: 'Defender', 3: 'Midfielder', 4: 'Forward', 5: 'Manager' }[playerOut.position] ?? playerOut.position } />
+                        <ListItemText
+                            primary={ playerOut.name }
+                            secondary={ `${ { 1: 'Goalkeeper', 2: 'Defender', 3: 'Midfielder', 4: 'Forward', 5: 'Manager' }[playerOut.position] ?? playerOut.position }${ (playerOut.sellingPrice ?? playerOut.nowCost) != null ? ` · £${((playerOut.sellingPrice ?? playerOut.nowCost) / 10).toFixed(1)}m` : '' }` }
+                        />
                     </ListItem>
                     { /* Player In: dropdown, only matching position */ }
                     <Autocomplete
@@ -113,7 +116,7 @@ const TransferPlayer = ({ team, allPlayers, onTransfer, playerOut, open, onClose
                                 <ListItem { ...props } key={ option.id }>
                                     <ListItemText 
                                         primary={ option.web_name || option.webName || option.name } 
-                                        secondary={ `${Math.round(option.ep_next) || 0} pts • ${opponentText}` } 
+                                        secondary={ `${Math.round(option.ep_next) || 0} pts · ${opponentText}${ (option.nowCost ?? option.now_cost) != null ? ` · £${((option.nowCost ?? option.now_cost) / 10).toFixed(1)}m` : '' }` } 
                                     />
                                 </ListItem>
                             );

--- a/frontend/src/components/TransferPlayer/TransferPlayer.jsx
+++ b/frontend/src/components/TransferPlayer/TransferPlayer.jsx
@@ -87,7 +87,7 @@ const TransferPlayer = ({ team, allPlayers, onTransfer, playerOut, open, onClose
                 <DialogContent>
                     { /* Player Out: fixed, not a dropdown */ }
                     <ListItem>
-                        <ListItemText primary={ playerOut.name } secondary={ playerOut.position } />
+                        <ListItemText primary={ playerOut.name } secondary={ { 1: 'Goalkeeper', 2: 'Defender', 3: 'Midfielder', 4: 'Forward', 5: 'Manager' }[playerOut.position] ?? playerOut.position } />
                     </ListItem>
                     { /* Player In: dropdown, only matching position */ }
                     <Autocomplete

--- a/frontend/src/hooks/usePlannedTransfers.js
+++ b/frontend/src/hooks/usePlannedTransfers.js
@@ -34,6 +34,8 @@ const usePlannedTransfers = () => {
           position: playerOut.position ?? playerOut.element_type,
           team: playerOut.team,
           predictedPoints: parseFloat(playerOut.basePoints ?? playerOut.predictedPoints ?? playerOut.ep_next ?? 0),
+          nowCost: playerOut.nowCost ?? playerOut.now_cost ?? null,
+          sellingPrice: playerOut.sellingPrice ?? playerOut.selling_price ?? playerOut.nowCost ?? playerOut.now_cost ?? null,
         },
         playerIn: {
           code: playerIn.code,
@@ -41,6 +43,7 @@ const usePlannedTransfers = () => {
           position: playerIn.position ?? playerIn.element_type,
           team: playerIn.team,
           predictedPoints: parseFloat(playerIn.ep_next ?? playerIn.predictedPoints ?? 0),
+          nowCost: playerIn.nowCost ?? playerIn.now_cost ?? null,
         },
         gameweek,
       };

--- a/frontend/src/hooks/useTeamData.js
+++ b/frontend/src/hooks/useTeamData.js
@@ -15,6 +15,7 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
   const [teamName, setTeamName] = useState('');
   const [gameweekInfo, setGameweekInfo] = useState(null);
   const [freeTransfers, setFreeTransfers] = useState(null);
+  const [bank, setBank] = useState(null);
   // Incremented each time the user successfully performs a manual substitution.
   // App.jsx watches this to skip selectOptimalLineup after a manual sub.
   const [swapVersion, setSwapVersion] = useState(0);
@@ -62,7 +63,7 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
       // internally — no separate /api/bootstrap-static call needed.
       const gameweekParam = selectedGameweek ? `?gameweek=${selectedGameweek}` : '';
       const response = await axios.get(`/api/entry/${entryId}/team${gameweekParam}`);
-      const { activePlayers: active, reservePlayers: reserve, teamName: fetchedTeamName, gameweek, currentGameweek, isPastGameweek, isFutureGameweek, isActiveGameweek, gameweekData, freeTransfers: ft } = response.data;
+      const { activePlayers: active, reservePlayers: reserve, teamName: fetchedTeamName, gameweek, currentGameweek, isPastGameweek, isFutureGameweek, isActiveGameweek, gameweekData, freeTransfers: ft, bank: bankBalance } = response.data;
 
       setGameweekInfo({
         selected: gameweek,
@@ -77,10 +78,12 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
       setReservePlayers(reserve);
       setTeamName(fetchedTeamName || '');
       setFreeTransfers(ft ?? null);
+      setBank(bankBalance ?? null);
     } catch (error) {
       setTeamName('');
       setGameweekInfo(null);
       setFreeTransfers(null);
+      setBank(null);
       console.error('Error fetching team data:', error);
     }
   }, [entryId, selectedGameweek]);
@@ -279,6 +282,7 @@ const calculateTotalPredictedPoints = (team) => {
     swapVersion,
     autoPickLineup,
     freeTransfers,
+    bank,
   };
 };
 


### PR DESCRIPTION
This pull request introduces comprehensive support for tracking and displaying player purchase and selling prices, as well as the user's team bank balance, including accurate projections after planned transfers. These improvements enhance both the backend logic for price calculations and the frontend UI, giving users clearer insight into their team's financials and the impact of future transfer plans.

Backend enhancements for price and bank tracking:
- Added logic in `getUserTeamForEntry` to fetch and process transfer history, calculating each player's accurate purchase and selling prices per FPL rules, and exposing these values in the API response.
- Exposed the user's bank balance in the `/api/entry/:id/team` endpoint response.
- Updated the `Player` entity to prioritize enriched `purchasePrice` and `sellingPrice` fields, falling back to API values as needed.
- Implemented `fetchEntryTransfers` in `dataProvider.js` to retrieve a team's transfer history from the FPL API, and exported it for controller use. [[1]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eR178-R194) [[2]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eR224)

Frontend UI and state improvements:
- Extended `useTeamData` to fetch and provide the bank balance alongside other team data, and updated state handling accordingly. [[1]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR18) [[2]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aL65-R66) [[3]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR81-R86) [[4]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR285)
- In `App.jsx`, added logic to display the projected bank balance for future gameweeks, factoring in the cumulative effect of planned transfers, and to show funds in/out for the viewed gameweek. Adjusted the stats grid to include this new information. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R65) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R224-R254) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L452-R484) [[4]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R497-R501) [[5]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R546-R557)

Player and transfer UI enhancements:
- Updated `PlayerCard` to show a price tag (selling price or now cost) for players in future gameweeks. [[1]](diffhunk://#diff-85ee03fef1cb942d9ddabea8e4e2d2ff4beaa6d5bbc613f6bc4bc9210de3fd6fR370-R388) [[2]](diffhunk://#diff-85ee03fef1cb942d9ddabea8e4e2d2ff4beaa6d5bbc613f6bc4bc9210de3fd6fR438)
- Improved `TransferPlayer` dialog to display selling price for the outgoing player and now cost for incoming options. [[1]](diffhunk://#diff-d80bad8cc1826b182646833c481eb7be9bdfdd4b73165da72029f604b771da19L90-R93) [[2]](diffhunk://#diff-d80bad8cc1826b182646833c481eb7be9bdfdd4b73165da72029f604b771da19L116-R119)
- Ensured planned transfers include `nowCost` and `sellingPrice` for both outgoing and incoming players in their data structure.

These changes provide users with a more accurate and transparent view of their team's financial state, particularly around transfer planning and future gameweek scenarios.