### PR TITLE
Implement lineup storage and Free Hit chip management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import axios from './api';
+import { saveChip, loadChip } from './utils/lineupStorage';
 import NavigationBar from './components/NavigationBar/NavigationBar';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
@@ -46,8 +47,26 @@ const App = () => {
   const [viewingOpponentId, setViewingOpponentId] = useState(null); // opponent team being viewed
   const [pitchView, setPitchView] = useState(() => localStorage.getItem('pitchView') || 'formation'); // 'formation' | 'list'
   const [activeChip, setActiveChip] = useState(null); // 'bench_boost' | 'triple_captain' | 'free_hit' | 'wildcard' | null
+  // Planned chips across all future GWs: { [gw]: chipId }.  Loaded from storage
+  // on mount and kept in sync whenever a chip is toggled.
+  const [plannedChipsByGW, setPlannedChipsByGW] = useState({});
 
-  const handleChipToggle = (chipId) => setActiveChip(prev => (prev === chipId ? null : chipId));
+  const handleChipToggle = (chipId) => {
+    const next = activeChip === chipId ? null : chipId;
+    setActiveChip(next);
+    const viewedGW = gameweekInfo?.selected;
+    if (!isHighestPredictedTeam && !isLockedGameweek && userEntryId && viewedGW) {
+      // Persist planned chip per-gameweek so it survives page refreshes.
+      // Only stored for future GWs — locked GWs read chip state from FPL directly.
+      saveChip(userEntryId, viewedGW, next);
+      setPlannedChipsByGW(prev => {
+        const updated = { ...prev };
+        if (next) updated[viewedGW] = next;
+        else delete updated[viewedGW];
+        return updated;
+      });
+    }
+  };
 
   const {
     activePlayers,
@@ -99,10 +118,60 @@ const App = () => {
       .catch(() => setUsedFplChips([]));
   }, [currentEntryId, isHighestPredictedTeam]);
 
-  // Clear active chip if it becomes unavailable (e.g. team changed)
+  // Load all future GW planned chips from localStorage into state whenever the
+  // entry or current gameweek changes (i.e. on mount and on team switch).
+  useEffect(() => {
+    if (!userEntryId || !currentGameweek) { setPlannedChipsByGW({}); return; }
+    const map = {};
+    for (let gw = currentGameweek + 1; gw <= 38; gw++) {
+      const chip = loadChip(userEntryId, gw);
+      if (chip) map[gw] = chip;
+    }
+    setPlannedChipsByGW(map);
+  }, [userEntryId, currentGameweek]);
+
+  // Set of future GW numbers where the user has planned a Free Hit chip.
+  // Only includes GWs where the chip is still available (not yet used in FPL).
+  const freeHitGWs = useMemo(() => {
+    const s = new Set();
+    if (!unusedChipIds.includes('free_hit')) return s;
+    Object.entries(plannedChipsByGW).forEach(([gw, chip]) => {
+      if (chip === 'free_hit') s.add(Number(gw));
+    });
+    return s;
+  }, [plannedChipsByGW, unusedChipIds]);
+
+  // Clear active chip from state if it becomes unavailable (e.g. team changed or
+  // chip already used in FPL).  The stored value is left intact so it can be
+  // re-applied if the user switches back to a valid gameweek.
   useEffect(() => {
     if (activeChip && !unusedChipIds.includes(activeChip)) setActiveChip(null);
   }, [unusedChipIds, activeChip]);
+
+  // Track the last gameweek we restored a chip for, so we only do it once per
+  // gameweek/entry combination and don't clobber a manual toggle on re-render.
+  const restoredChipKey = useRef(null);
+
+  // Restore stored chip when loading a future gameweek for the user's own team.
+  useEffect(() => {
+    if (
+      !gameweekInfo?.isFuture ||
+      isHighestPredictedTeam ||
+      viewingOpponentId ||
+      !userEntryId
+    ) return;
+    const viewedGW = gameweekInfo.selected;
+    const key = `${userEntryId}_${viewedGW}`;
+    if (restoredChipKey.current === key) return; // already restored for this GW
+    restoredChipKey.current = key;
+    const stored = loadChip(userEntryId, viewedGW);
+    // Only restore if the chip is still available (not yet used in FPL)
+    if (stored && unusedChipIds.includes(stored)) {
+      setActiveChip(stored);
+    } else {
+      setActiveChip(null);
+    }
+  }, [gameweekInfo, isHighestPredictedTeam, viewingOpponentId, userEntryId, unusedChipIds]);
 
   useEffect(() => {
     if (snackbar.message) setSnackbarOpen(true);
@@ -167,55 +236,79 @@ const App = () => {
       return { effectiveActivePlayers: activePlayers, effectiveReservePlayers: reservePlayers };
     }
 
-    let newActive = [...activePlayers];
-    let newReserve = [...reservePlayers];
-
-    for (const transfer of applicableTransfers) {
-      const playerInData = allPlayers.find(p => p.code === transfer.playerIn.code);
-      if (!playerInData) continue;
-
-      // Base points come from ep_next on the enriched allPlayers element.
-      const basePoints = Math.round(parseFloat(playerInData.ep_next) || 0);
-
-      const activeIdx = newActive.findIndex(p => p.code === transfer.playerOut.code);
-      if (activeIdx !== -1) {
-        const old = newActive[activeIdx];
-        const multiplier = old.multiplier || 1;
-        newActive = [...newActive];
-        newActive[activeIdx] = {
-          ...playerInData,
-          isActive: old.isActive,
-          slot: old.slot,
-          user_team: old.user_team,
-          is_captain: old.is_captain,
-          is_vice_captain: old.is_vice_captain,
-          multiplier,
-          basePoints,
-          predictedPoints: basePoints * multiplier,
-        };
-        continue;
+    // Helper: apply a list of transfers on top of active/reserve arrays.
+    const applyTransfers = (active, reserve, transfers) => {
+      let a = active;
+      let r = reserve;
+      for (const transfer of transfers) {
+        const playerInData = allPlayers.find(p => p.code === transfer.playerIn.code);
+        if (!playerInData) continue;
+        const basePoints = Math.round(parseFloat(playerInData.ep_next) || 0);
+        const activeIdx = a.findIndex(p => p.code === transfer.playerOut.code);
+        if (activeIdx !== -1) {
+          const old = a[activeIdx];
+          const multiplier = old.multiplier || 1;
+          a = [...a];
+          a[activeIdx] = {
+            ...playerInData,
+            isActive: old.isActive,
+            slot: old.slot,
+            user_team: old.user_team,
+            is_captain: old.is_captain,
+            is_vice_captain: old.is_vice_captain,
+            multiplier,
+            basePoints,
+            predictedPoints: basePoints * multiplier,
+          };
+          continue;
+        }
+        const reserveIdx = r.findIndex(p => p.code === transfer.playerOut.code);
+        if (reserveIdx !== -1) {
+          const old = r[reserveIdx];
+          r = [...r];
+          r[reserveIdx] = {
+            ...playerInData,
+            isActive: old.isActive,
+            slot: old.slot,
+            user_team: old.user_team,
+            is_captain: old.is_captain,
+            is_vice_captain: old.is_vice_captain,
+            multiplier: 1,
+            basePoints,
+            predictedPoints: basePoints,
+          };
+        }
       }
+      return { a, r };
+    };
 
-      const reserveIdx = newReserve.findIndex(p => p.code === transfer.playerOut.code);
-      if (reserveIdx !== -1) {
-        const old = newReserve[reserveIdx];
-        newReserve = [...newReserve];
-        newReserve[reserveIdx] = {
-          ...playerInData,
-          isActive: old.isActive,
-          slot: old.slot,
-          user_team: old.user_team,
-          is_captain: old.is_captain,
-          is_vice_captain: old.is_vice_captain,
-          multiplier: 1,
-          basePoints,
-          predictedPoints: basePoints,
-        };
-      }
+    // Group transfers by GW so we can process them one gameweek at a time.
+    const transfersByGW = {};
+    for (const t of applicableTransfers) {
+      if (!transfersByGW[t.gameweek]) transfersByGW[t.gameweek] = [];
+      transfersByGW[t.gameweek].push(t);
     }
 
-    return { effectiveActivePlayers: newActive, effectiveReservePlayers: newReserve };
-  }, [gameweekInfo, isLockedGameweek, isHighestPredictedTeam, currentGameweek, plannedTransfers, activePlayers, reservePlayers, allPlayers]);
+    let runActive  = [...activePlayers];
+    let runReserve = [...reservePlayers];
+
+    for (let gw = currentGameweek + 1; gw <= targetGW; gw++) {
+      const gwTransfers = transfersByGW[gw];
+      if (!gwTransfers || gwTransfers.length === 0) continue;
+
+      // Free Hit reverts the squad after the GW it is played.  Transfers in a
+      // Free Hit GW should only affect the display when viewing *that exact GW* —
+      // they must not carry forward to subsequent GWs.
+      const isFH = freeHitGWs.has(gw);
+      if (isFH && gw < targetGW) continue;
+
+      const { a, r } = applyTransfers(runActive, runReserve, gwTransfers);
+      runActive  = a;
+      runReserve = r;
+    }
+
+    return { effectiveActivePlayers: runActive, effectiveReservePlayers: runReserve };
+  }, [gameweekInfo, isLockedGameweek, isHighestPredictedTeam, currentGameweek, plannedTransfers, activePlayers, reservePlayers, allPlayers, freeHitGWs]);
 
   // Planned transfers shown to pitch/bench components — suppressed for locked GWs
   // so stale planned-transfer badges don't render on top of actual picks data.
@@ -231,7 +324,13 @@ const App = () => {
     const viewedGW = gameweekInfo?.selected ?? currentGameweek;
     // Apply cumulative transfer cost deltas up to and including viewedGW.
     const delta = plannedTransfers
-      .filter(t => t.gameweek <= viewedGW)
+      .filter(t => {
+        if (t.gameweek > viewedGW) return false;
+        // Free Hit transfers at a previous GW revert — their cost doesn't
+        // carry forward to the bank balance for subsequent GWs.
+        if (freeHitGWs.has(t.gameweek) && t.gameweek < viewedGW) return false;
+        return true;
+      })
       .reduce((sum, t) => {
         const sellPrice = t.playerOut.sellingPrice ?? t.playerOut.nowCost ?? 0;
         const buyPrice  = t.playerIn.nowCost ?? 0;
@@ -297,7 +396,9 @@ const App = () => {
     // Rule: ft_next = min(2, max(0, ft - transfers_made) + 1)
     let simulatedFreeTransfers = freeTransfers;
     for (let gw = currentGameweek; gw < viewedGW; gw += 1) {
-      const transfersThisGW = plannedTransfersByGW[gw] || 0;
+      // Free Hit transfers don't permanently consume free transfers — treat
+      // the GW as if 0 transfers were made for carry-over purposes.
+      const transfersThisGW = freeHitGWs.has(gw) ? 0 : (plannedTransfersByGW[gw] || 0);
       simulatedFreeTransfers = Math.min(2, Math.max(0, simulatedFreeTransfers - transfersThisGW) + 1);
     }
 
@@ -374,6 +475,9 @@ const App = () => {
 
     let squad = [...activePlayers, ...reservePlayers];
     for (const t of applicable) {
+      // Free Hit transfers at a GW before targetGW revert — don't modify the
+      // permanent squad composition used for club-limit validation.
+      if (freeHitGWs.has(t.gameweek) && t.gameweek < targetGW) continue;
       const playerInData = allPlayers.find(p => p.code === t.playerIn.code);
       if (!playerInData) continue;
       const idx = squad.findIndex(p => p.code === t.playerOut.code);
@@ -647,6 +751,7 @@ const App = () => {
               team={ [...activePlayers, ...reservePlayers] }
               allPlayers={ allPlayers }
               voidedTransferIds={ voidedTransferIds }
+              freeHitGWs={ freeHitGWs }
             />
           </Box>
         </Box>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import axios from './api';
 import { saveChip, loadChip } from './utils/lineupStorage';
+import { computeProjectedBank, simulateFreeTransferCarryover } from './utils/freeHitSimulation';
 import NavigationBar from './components/NavigationBar/NavigationBar';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
@@ -322,22 +323,8 @@ const App = () => {
     if (isHighestPredictedTeam || viewingOpponentId || bank == null) return null;
     if (!gameweekInfo?.isFuture) return null; // Only show for future GWs
     const viewedGW = gameweekInfo?.selected ?? currentGameweek;
-    // Apply cumulative transfer cost deltas up to and including viewedGW.
-    const delta = plannedTransfers
-      .filter(t => {
-        if (t.gameweek > viewedGW) return false;
-        // Free Hit transfers at a previous GW revert — their cost doesn't
-        // carry forward to the bank balance for subsequent GWs.
-        if (freeHitGWs.has(t.gameweek) && t.gameweek < viewedGW) return false;
-        return true;
-      })
-      .reduce((sum, t) => {
-        const sellPrice = t.playerOut.sellingPrice ?? t.playerOut.nowCost ?? 0;
-        const buyPrice  = t.playerIn.nowCost ?? 0;
-        return sum + sellPrice - buyPrice;
-      }, 0);
-    return bank + delta;
-  }, [isHighestPredictedTeam, viewingOpponentId, bank, gameweekInfo, currentGameweek, plannedTransfers]);
+    return computeProjectedBank(bank, plannedTransfers, viewedGW, freeHitGWs);
+  }, [isHighestPredictedTeam, viewingOpponentId, bank, gameweekInfo, currentGameweek, plannedTransfers, freeHitGWs]);
 
   // Funds coming in (sum of selling prices) and going out (sum of buying prices)
   // for planned transfers scheduled for the viewed GW specifically.
@@ -392,15 +379,11 @@ const App = () => {
       return counts;
     }, {});
 
-    // Simulate FT carry-over from the current GW up to (but not including) the viewed GW.
-    // Rule: ft_next = min(2, max(0, ft - transfers_made) + 1)
-    let simulatedFreeTransfers = freeTransfers;
-    for (let gw = currentGameweek; gw < viewedGW; gw += 1) {
-      // Free Hit transfers don't permanently consume free transfers — treat
-      // the GW as if 0 transfers were made for carry-over purposes.
-      const transfersThisGW = freeHitGWs.has(gw) ? 0 : (plannedTransfersByGW[gw] || 0);
-      simulatedFreeTransfers = Math.min(2, Math.max(0, simulatedFreeTransfers - transfersThisGW) + 1);
-    }
+    // Simulate FT carry-over from the current GW up to (but not including) the viewed GW,
+    // treating Free Hit GWs as if 0 transfers were made (FH squad reverts).
+    const simulatedFreeTransfers = simulateFreeTransferCarryover(
+      freeTransfers, currentGameweek, viewedGW, plannedTransfersByGW, freeHitGWs
+    );
 
     // For locked GWs the actual picks are authoritative — don't subtract planned transfers.
     const plannedCount = isLockedGameweek ? 0 : (plannedTransfersByGW[viewedGW] || 0);
@@ -410,7 +393,7 @@ const App = () => {
       remaining: Math.max(0, remaining),
       cost: remaining < 0 ? remaining * 4 : 0, // negative value = points deduction
     };
-  }, [isHighestPredictedTeam, viewingOpponentId, freeTransfers, gameweekInfo, currentGameweek, activeChip, plannedTransfers, isLockedGameweek]);
+  }, [isHighestPredictedTeam, viewingOpponentId, freeTransfers, gameweekInfo, currentGameweek, activeChip, plannedTransfers, isLockedGameweek, freeHitGWs]);
 
   // Handle setting team ID (saves to localStorage)
   const handleSetTeamId = (teamId) => {

--- a/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
+++ b/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
@@ -325,6 +325,7 @@ const PlannedTransfers = ({
   currentGameweek,
   compact = false,
   voidedTransferIds = new Set(),
+  freeHitGWs = new Set(),
 }) => {
   const theme = useTheme();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -373,6 +374,7 @@ const PlannedTransfers = ({
           <Box sx={ { display: 'flex', flexDirection: 'column', gap: 1 } }>
             { sorted.map((t, idx) => {
               const isVoided = voidedTransferIds.has(t.id);
+              const isFH = freeHitGWs.has(t.gameweek);
               const outForecast = buildForecast(t.playerOut.code, t.gameweek);
               const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
               const totalDiff =
@@ -385,6 +387,15 @@ const PlannedTransfers = ({
                     <Typography variant='caption' color='warning.main' sx={ { display: 'block', mb: 0.25, fontStyle: 'italic' } }>
                       Not made – transfer was not executed in FPL
                     </Typography>
+                  ) }
+                  { isFH && !isVoided && (
+                    <Tooltip title={ `Free Hit active — this transfer reverts after GW${t.gameweek}` }>
+                      <Chip
+                        label='Free Hit'
+                        size='small'
+                        sx={ { height: 18, fontSize: '0.6rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', mb: 0.5, cursor: 'default' } }
+                      />
+                    </Tooltip>
                   ) }
                   <Box
                     sx={ {
@@ -474,6 +485,7 @@ const PlannedTransfers = ({
             <TableBody>
               { sorted.map((t) => {
                 const isVoided = voidedTransferIds.has(t.id);
+                const isFH = freeHitGWs.has(t.gameweek);
                 const outForecast = buildForecast(t.playerOut.code, t.gameweek);
                 const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
                 const totalDiff =
@@ -493,6 +505,15 @@ const PlannedTransfers = ({
                         <Typography variant='caption' color='warning.main' sx={ { display: 'block', fontStyle: 'italic' } }>
                           Not made
                         </Typography>
+                      ) }
+                      { isFH && !isVoided && (
+                        <Tooltip title={ `Free Hit active — this transfer reverts after GW${t.gameweek}` }>
+                          <Chip
+                            label='Free Hit'
+                            size='small'
+                            sx={ { height: 18, fontSize: '0.6rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', mb: 0.5, cursor: 'default' } }
+                          />
+                        </Tooltip>
                       ) }
                       <Typography
                         variant='body2'
@@ -565,6 +586,7 @@ PlannedTransfers.propTypes = {
   currentGameweek: PropTypes.number,
   compact: PropTypes.bool,
   voidedTransferIds: PropTypes.instanceOf(Set),
+  freeHitGWs: PropTypes.instanceOf(Set),
 };
 
 export default PlannedTransfers;

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -19,6 +19,7 @@ const TeamActivityPanel = ({
   team,
   allPlayers,
   voidedTransferIds,
+  freeHitGWs,
 }) => {
   const theme = useTheme();
   const [profile, setProfile] = useState(null);
@@ -292,6 +293,7 @@ const TeamActivityPanel = ({
             currentGameweek={ currentGameweek }
             compact={ true }
             voidedTransferIds={ voidedTransferIds }
+            freeHitGWs={ freeHitGWs }
           />
         </Paper>
       ) }
@@ -328,6 +330,7 @@ TeamActivityPanel.propTypes = {
   team: PropTypes.array,
   allPlayers: PropTypes.array,
   voidedTransferIds: PropTypes.instanceOf(Set),
+  freeHitGWs: PropTypes.instanceOf(Set),
 };
 
 export default TeamActivityPanel;

--- a/frontend/src/hooks/useTeamData.js
+++ b/frontend/src/hooks/useTeamData.js
@@ -5,6 +5,7 @@ import {
   applySubstitution,
   selectOptimalLineup,
 } from '../utils/substitution';
+import { saveLineup, loadLineup, restoreLineup } from '../utils/lineupStorage';
 
 const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGameweek = null) => {
   const [activePlayers, setActivePlayers] = useState([]);
@@ -19,6 +20,14 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
   // Incremented each time the user successfully performs a manual substitution.
   // App.jsx watches this to skip selectOptimalLineup after a manual sub.
   const [swapVersion, setSwapVersion] = useState(0);
+  // Tracks the gameweek number of the currently loaded data so that the save
+  // effect has a stable value even when gameweekInfo hasn't yet re-rendered.
+  const [loadedGameweek, setLoadedGameweek] = useState(null);
+  // Set of player codes from the most recently loaded current/past/active GW.
+  // Used as the fingerprint comparison baseline when restoring a future-GW
+  // lineup, because the future-GW API re-optimises the squad ordering and
+  // should not be treated as the authoritative squad composition.
+  const [currentSquadCodes, setCurrentSquadCodes] = useState(null);
 
   // Sync internal state with prop changes (e.g., when restoring session)
   useEffect(() => {
@@ -40,6 +49,7 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
         isActive: isActiveGameweek,
         data: gameweekData
       });
+      setLoadedGameweek(null); // highest predicted team is never persisted
       
       setActivePlayers(active);
       setReservePlayers(reserve);
@@ -73,9 +83,33 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
         isActive: isActiveGameweek,
         data: gameweekData
       });
+      setLoadedGameweek(isFutureGameweek ? gameweek : null);
 
-      setActivePlayers(active);
-      setReservePlayers(reserve);
+      // Always capture the current squad codes when loading the actual (non-
+      // future) GW so we have a reliable baseline for fingerprint comparison.
+      if (!isFutureGameweek) {
+        setCurrentSquadCodes(new Set([...active, ...reserve].map((p) => p.code)));
+      }
+
+      // For future gameweeks, attempt to restore a previously saved lineup
+      // selection (substitutions, bench order, captain).  If the squad
+      // fingerprint no longer matches (transfer was made), the stored data is
+      // discarded and the fresh API data is used as-is.
+      let finalActive = active;
+      let finalReserve = reserve;
+      if (isFutureGameweek && entryId) {
+        const stored = loadLineup(entryId, gameweek);
+        // Pass currentSquadCodes (last real GW) as the comparison base so that
+        // the re-optimised future-GW player ordering cannot mask real transfers.
+        const restored = restoreLineup(active, reserve, stored, currentSquadCodes);
+        if (restored) {
+          finalActive = restored.activePlayers;
+          finalReserve = restored.reservePlayers;
+        }
+      }
+
+      setActivePlayers(finalActive);
+      setReservePlayers(finalReserve);
       setTeamName(fetchedTeamName || '');
       setFreeTransfers(ft ?? null);
       setBank(bankBalance ?? null);
@@ -93,6 +127,15 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
       fetchData();
     }
   }, [fetchData, isHighestPredictedTeam]);
+
+  // Persist lineup selection to localStorage whenever the user changes their
+  // starting XI, bench order, or captain for a future gameweek.  Saved after
+  // every state update so swaps, auto-pick, and captain changes are all covered.
+  // Not saved for locked (past/active) GWs — those use FPL API data directly.
+  useEffect(() => {
+    if (!entryId || !loadedGameweek || isHighestPredictedTeam || activePlayers.length === 0) return;
+    saveLineup(entryId, loadedGameweek, activePlayers, reservePlayers);
+  }, [activePlayers, reservePlayers, entryId, loadedGameweek, isHighestPredictedTeam]);
 
   // Handle player selection and swapping (only for user's team)
   //

--- a/frontend/src/hooks/useTeamData.js
+++ b/frontend/src/hooks/useTeamData.js
@@ -23,6 +23,11 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
   // Tracks the gameweek number of the currently loaded data so that the save
   // effect has a stable value even when gameweekInfo hasn't yet re-rendered.
   const [loadedGameweek, setLoadedGameweek] = useState(null);
+  // Tracks the entryId whose data is currently held in activePlayers/reservePlayers.
+  // Ensures the lineup-persist effect only writes when the loaded data actually
+  // belongs to the current entryId (prevents the old entry's lineup being saved
+  // under the new entry's localStorage key immediately after an entryId change).
+  const [loadedEntryId, setLoadedEntryId] = useState(null);
   // Set of player codes from the most recently loaded current/past/active GW.
   // Used as the fingerprint comparison baseline when restoring a future-GW
   // lineup, because the future-GW API re-optimises the squad ordering and
@@ -113,6 +118,9 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
       setTeamName(fetchedTeamName || '');
       setFreeTransfers(ft ?? null);
       setBank(bankBalance ?? null);
+      // Mark which entry's data is now in state so the persist effect can guard
+      // against writing the old lineup under a newly-switched entry's key.
+      setLoadedEntryId(entryId);
     } catch (error) {
       setTeamName('');
       setGameweekInfo(null);
@@ -132,10 +140,14 @@ const useTeamData = (entryId, isHighestPredictedTeamInit = true, selectedGamewee
   // starting XI, bench order, or captain for a future gameweek.  Saved after
   // every state update so swaps, auto-pick, and captain changes are all covered.
   // Not saved for locked (past/active) GWs — those use FPL API data directly.
+  // Guard: only save when loadedEntryId matches entryId to prevent the stale
+  // lineup from the previous entry being written under the new entry's key
+  // immediately after an entryId switch (before the new data has loaded).
   useEffect(() => {
     if (!entryId || !loadedGameweek || isHighestPredictedTeam || activePlayers.length === 0) return;
+    if (loadedEntryId !== entryId) return;
     saveLineup(entryId, loadedGameweek, activePlayers, reservePlayers);
-  }, [activePlayers, reservePlayers, entryId, loadedGameweek, isHighestPredictedTeam]);
+  }, [activePlayers, reservePlayers, entryId, loadedGameweek, isHighestPredictedTeam, loadedEntryId]);
 
   // Handle player selection and swapping (only for user's team)
   //

--- a/frontend/src/utils/freeHitSimulation.js
+++ b/frontend/src/utils/freeHitSimulation.js
@@ -1,0 +1,57 @@
+/**
+ * Pure helper functions for Free Hit chip simulation.
+ *
+ * These are extracted from the useMemo hooks in App.jsx so they can be
+ * independently unit-tested without rendering the full component.
+ */
+
+/**
+ * Compute the projected bank balance after applying cumulative planned transfers
+ * up to and including `viewedGW`, skipping any Free Hit transfers at gameweeks
+ * *before* the viewed GW (because Free Hit squads revert after that GW).
+ *
+ * @param {number}   bank              - Current bank balance (in tenths of £m, e.g. 50 = £5.0m).
+ * @param {Array}    plannedTransfers  - Array of planned transfer objects with gameweek, playerOut and playerIn.
+ * @param {number}   viewedGW          - The gameweek being viewed.
+ * @param {Set<number>} freeHitGWs     - Set of GW numbers where Free Hit is planned.
+ * @returns {number} Projected bank balance.
+ */
+export function computeProjectedBank(bank, plannedTransfers, viewedGW, freeHitGWs) {
+  const delta = plannedTransfers
+    .filter(t => {
+      if (t.gameweek > viewedGW) return false;
+      // Free Hit transfers at a prior GW revert — their cost doesn't carry forward.
+      if (freeHitGWs.has(t.gameweek) && t.gameweek < viewedGW) return false;
+      return true;
+    })
+    .reduce((sum, t) => {
+      const sellPrice = t.playerOut.sellingPrice ?? t.playerOut.nowCost ?? 0;
+      const buyPrice  = t.playerIn.nowCost ?? 0;
+      return sum + sellPrice - buyPrice;
+    }, 0);
+  return bank + delta;
+}
+
+/**
+ * Simulate free transfer carry-over from `currentGW` up to (but not including)
+ * `viewedGW`, treating Free Hit gameweeks as if 0 transfers were made (since
+ * the Free Hit squad reverts and FTs are not permanently consumed).
+ *
+ * Rule: ft_next = min(2, max(0, ft - transfers_made) + 1)
+ *
+ * @param {number}      freeTransfers        - Starting free transfer count for currentGW.
+ * @param {number}      currentGW            - The current (live) gameweek.
+ * @param {number}      viewedGW             - The future gameweek being projected.
+ * @param {Object}      plannedTransfersByGW - Map of { [gw]: count } planned transfers per GW.
+ * @param {Set<number>} freeHitGWs           - Set of GW numbers where Free Hit is planned.
+ * @returns {number} Simulated free transfer count at the start of viewedGW.
+ */
+export function simulateFreeTransferCarryover(freeTransfers, currentGW, viewedGW, plannedTransfersByGW, freeHitGWs) {
+  let ft = freeTransfers;
+  for (let gw = currentGW; gw < viewedGW; gw++) {
+    // Free Hit transfers don't permanently consume free transfers.
+    const transfersThisGW = freeHitGWs.has(gw) ? 0 : (plannedTransfersByGW[gw] || 0);
+    ft = Math.min(2, Math.max(0, ft - transfersThisGW) + 1);
+  }
+  return ft;
+}

--- a/frontend/src/utils/freeHitSimulation.test.js
+++ b/frontend/src/utils/freeHitSimulation.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { computeProjectedBank, simulateFreeTransferCarryover } from './freeHitSimulation';
+
+// ── computeProjectedBank ─────────────────────────────────────────────────────
+
+describe('computeProjectedBank', () => {
+  it('returns bank unchanged when no planned transfers exist', () => {
+    expect(computeProjectedBank(100, [], 26, new Set())).toBe(100);
+  });
+
+  it('applies a normal (non-FH) transfer cost delta for the viewed GW', () => {
+    // sell for 80, buy for 90 → delta = -10
+    const transfers = [{ gameweek: 26, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }];
+    expect(computeProjectedBank(100, transfers, 26, new Set())).toBe(90);
+  });
+
+  it('applies a normal transfer that yields profit (sell high, buy cheap)', () => {
+    // sell for 100, buy for 70 → delta = +30
+    const transfers = [{ gameweek: 26, playerOut: { nowCost: 100 }, playerIn: { nowCost: 70 } }];
+    expect(computeProjectedBank(50, transfers, 26, new Set())).toBe(80);
+  });
+
+  it('accumulates deltas from multiple non-FH GWs up to viewedGW', () => {
+    const transfers = [
+      { gameweek: 26, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }, // -10
+      { gameweek: 27, playerOut: { nowCost: 60 }, playerIn: { nowCost: 50 } }, // +10
+    ];
+    // net delta = 0; bank unchanged
+    expect(computeProjectedBank(100, transfers, 27, new Set())).toBe(100);
+  });
+
+  it('excludes transfers beyond the viewed GW', () => {
+    const transfers = [
+      { gameweek: 26, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }, // -10
+      { gameweek: 28, playerOut: { nowCost: 50 }, playerIn: { nowCost: 40 } }, // +10 (future, excluded)
+    ];
+    expect(computeProjectedBank(100, transfers, 26, new Set())).toBe(90);
+  });
+
+  it('excludes Free Hit transfers at a GW *before* the viewed GW', () => {
+    // GW25 = Free Hit; GW26 = viewed. The GW25 transfer should NOT affect bank.
+    const transfers = [
+      { gameweek: 25, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }, // FH - skip
+    ];
+    expect(computeProjectedBank(100, transfers, 26, new Set([25]))).toBe(100);
+  });
+
+  it('includes a Free Hit transfer at the *viewed* GW itself', () => {
+    // When viewing the exact FH GW the transfers are visible to the user.
+    const transfers = [
+      { gameweek: 26, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }, // -10
+    ];
+    expect(computeProjectedBank(100, transfers, 26, new Set([26]))).toBe(90);
+  });
+
+  it('excludes multiple Free Hit transfers from a prior GW while keeping a normal transfer', () => {
+    const freeHitGWs = new Set([25]);
+    const transfers = [
+      { gameweek: 25, playerOut: { nowCost: 80 }, playerIn: { nowCost: 90 } }, // FH prior - skip
+      { gameweek: 25, playerOut: { nowCost: 70 }, playerIn: { nowCost: 60 } }, // FH prior - skip
+      { gameweek: 26, playerOut: { nowCost: 50 }, playerIn: { nowCost: 40 } }, // normal - include (+10)
+    ];
+    expect(computeProjectedBank(100, transfers, 26, freeHitGWs)).toBe(110);
+  });
+
+  it('uses sellingPrice over nowCost for playerOut when both present', () => {
+    const transfers = [
+      { gameweek: 26, playerOut: { sellingPrice: 85, nowCost: 80 }, playerIn: { nowCost: 90 } },
+    ];
+    // delta = 85 - 90 = -5
+    expect(computeProjectedBank(100, transfers, 26, new Set())).toBe(95);
+  });
+});
+
+// ── simulateFreeTransferCarryover ────────────────────────────────────────────
+
+describe('simulateFreeTransferCarryover', () => {
+  it('returns starting FTs unchanged when viewing the current GW', () => {
+    // currentGW === viewedGW → loop never runs
+    expect(simulateFreeTransferCarryover(1, 25, 25, {}, new Set())).toBe(1);
+  });
+
+  it('carries over 1 FT to 2 when no transfers made (standard accumulation)', () => {
+    // 1 FT, no transfers in GW25 → ft_26 = min(2, max(0, 1 - 0) + 1) = 2
+    expect(simulateFreeTransferCarryover(1, 25, 26, {}, new Set())).toBe(2);
+  });
+
+  it('caps FT carry-over at 2 even with multiple idle GWs', () => {
+    // 2 FTs, no transfers → stays at 2
+    expect(simulateFreeTransferCarryover(2, 25, 27, {}, new Set())).toBe(2);
+  });
+
+  it('reduces FTs by transfers made in non-FH GWs', () => {
+    // 2 FT; 1 transfer in GW25 → ft_26 = min(2, max(0, 2-1)+1) = 2; then ft_27 = 2 still if no transfer
+    expect(simulateFreeTransferCarryover(2, 25, 26, { 25: 1 }, new Set())).toBe(2);
+  });
+
+  it('does not reduce FTs for transfers in a Free Hit GW', () => {
+    // GW25 = FH; 5 transfers planned but should be treated as 0
+    const freeHitGWs = new Set([25]);
+    // ft_26 = min(2, max(0, 1 - 0) + 1) = 2
+    expect(simulateFreeTransferCarryover(1, 25, 26, { 25: 5 }, freeHitGWs)).toBe(2);
+  });
+
+  it('correctly skips FH GW mid-chain and accumulates normally before/after', () => {
+    // GW25 normal: 1 transfer; GW26 FH: 5 transfers (skipped); viewing GW27
+    // ft after GW25: min(2, max(0, 1-1)+1) = 1
+    // ft after GW26 (FH, 0 effective): min(2, max(0, 1-0)+1) = 2
+    const freeHitGWs = new Set([26]);
+    expect(simulateFreeTransferCarryover(1, 25, 27, { 25: 1, 26: 5 }, freeHitGWs)).toBe(2);
+  });
+
+  it('clamps FTs to 0 when more transfers than available in non-FH GW', () => {
+    // 1 FT, 3 transfers in GW25 → max(0, 1-3) = 0, then +1 = 1
+    expect(simulateFreeTransferCarryover(1, 25, 26, { 25: 3 }, new Set())).toBe(1);
+  });
+
+  it('handles multi-GW simulation correctly from currentGW to viewedGW', () => {
+    // GW25: 0 transfers → ft=2; GW26: 2 transfers → ft=min(2, max(0,2-2)+1)=1; viewing GW27
+    expect(simulateFreeTransferCarryover(1, 25, 27, { 26: 2 }, new Set())).toBe(1);
+  });
+});

--- a/frontend/src/utils/lineupStorage.js
+++ b/frontend/src/utils/lineupStorage.js
@@ -1,0 +1,221 @@
+/**
+ * Persist a user's team lineup selection (starting XI / bench order / captain)
+ * to localStorage so it survives page refreshes.
+ *
+ * The stored data is keyed by entryId + gameweek and includes a "fingerprint"
+ * of the 15 player codes in the squad.  If the fingerprint no longer matches
+ * the live squad (because a transfer was made since the data was saved), the
+ * stored selection is discarded and the fresh API data is used instead.
+ *
+ * Only future gameweeks are persisted — past and active (locked) gameweeks
+ * always use the FPL API response as the authoritative source.
+ */
+
+const STORAGE_VERSION = 1;
+
+function storageKey(entryId, gameweek) {
+  return `fpl_lineup_v${STORAGE_VERSION}_${entryId}_${gameweek}`;
+}
+
+/** Sorted array of all 15 player codes — used to detect squad changes. */
+function buildFingerprint(activePlayers, reservePlayers) {
+  return [...activePlayers, ...reservePlayers]
+    .map((p) => p.code)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Save the current lineup to localStorage.
+ *
+ * @param {string|number} entryId
+ * @param {number}        gameweek
+ * @param {Object[]}      activePlayers  - Starting XI player objects.
+ * @param {Object[]}      reservePlayers - Bench player objects.
+ */
+export function saveLineup(entryId, gameweek, activePlayers, reservePlayers) {
+  if (!entryId || !gameweek || activePlayers.length === 0) return;
+  try {
+    const allPlayers = [...activePlayers, ...reservePlayers];
+    const captainCode = activePlayers.find((p) => p.is_captain)?.code ?? null;
+    const viceCaptainCode = allPlayers.find((p) => p.is_vice_captain)?.code ?? null;
+
+    const data = {
+      fingerprint: buildFingerprint(activePlayers, reservePlayers),
+      activePlayerCodes: activePlayers.map((p) => ({ code: p.code, slot: p.slot })),
+      reservePlayerCodes: reservePlayers.map((p) => ({ code: p.code, slot: p.slot })),
+      captainCode,
+      viceCaptainCode,
+    };
+    localStorage.setItem(storageKey(entryId, gameweek), JSON.stringify(data));
+  } catch {
+    // localStorage can fail (quota exceeded, private mode, etc.) — silently ignore.
+  }
+}
+
+/**
+ * Load a previously saved lineup snapshot.
+ *
+ * @param {string|number} entryId
+ * @param {number}        gameweek
+ * @returns {Object|null} Stored snapshot, or null if none exists.
+ */
+export function loadLineup(entryId, gameweek) {
+  if (!entryId || !gameweek) return null;
+  try {
+    const raw = localStorage.getItem(storageKey(entryId, gameweek));
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove a stored lineup snapshot (e.g. after gameweek locks).
+ *
+ * @param {string|number} entryId
+ * @param {number}        gameweek
+ */
+export function clearLineup(entryId, gameweek) {
+  if (!entryId || !gameweek) return;
+  try {
+    localStorage.removeItem(storageKey(entryId, gameweek));
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Chip storage ────────────────────────────────────────────────────────────
+// Stored separately from the lineup so chip selections can be toggled
+// independently (e.g. before any subs have been made).
+
+function chipStorageKey(entryId, gameweek) {
+  return `fpl_chip_v${STORAGE_VERSION}_${entryId}_${gameweek}`;
+}
+
+/**
+ * Save the user's planned chip selection for a future gameweek.
+ * Passing null clears the stored value.
+ *
+ * @param {string|number}  entryId
+ * @param {number}         gameweek
+ * @param {string|null}    chipId   - e.g. 'bench_boost', 'triple_captain', or null to clear.
+ */
+export function saveChip(entryId, gameweek, chipId) {
+  if (!entryId || !gameweek) return;
+  try {
+    if (chipId) {
+      localStorage.setItem(chipStorageKey(entryId, gameweek), chipId);
+    } else {
+      localStorage.removeItem(chipStorageKey(entryId, gameweek));
+    }
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Load a previously saved chip selection for a future gameweek.
+ *
+ * @param {string|number} entryId
+ * @param {number}        gameweek
+ * @returns {string|null} Chip id, or null if none stored.
+ */
+export function loadChip(entryId, gameweek) {
+  if (!entryId || !gameweek) return null;
+  try {
+    return localStorage.getItem(chipStorageKey(entryId, gameweek)) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to reconstruct a lineup from a stored snapshot using freshly-fetched
+ * player objects (which carry up-to-date predicted points, form, etc.).
+ *
+ * Returns null if the squad composition has changed since the snapshot was
+ * saved (indicating a transfer was made), in which case the caller should fall
+ * back to the plain API data.
+ *
+ * @param {Object[]}   freshActive    - Starting XI returned by the API (used for player objects).
+ * @param {Object[]}   freshReserve   - Bench returned by the API (used for player objects).
+ * @param {Object}     stored         - Snapshot previously returned by loadLineup().
+ * @param {Set<number>} [baseCodesSet] - Set of player codes from the last known actual squad
+ *   (e.g. current GW picks).  When provided this is used for the fingerprint comparison
+ *   instead of freshActive + freshReserve.  This ensures that a re-optimised future-GW
+ *   response (same 15 players, different predicted-point ordering) cannot mask a real
+ *   transfer that changed the squad composition.
+ * @returns {{ activePlayers: Object[], reservePlayers: Object[] } | null}
+ */
+export function restoreLineup(freshActive, freshReserve, stored, baseCodesSet) {
+  if (!stored) return null;
+
+  const allFresh = [...freshActive, ...freshReserve];
+
+  // Use the caller-supplied base squad codes when available (current/last GW
+  // actual picks), otherwise fall back to the future-GW player list.
+  const comparisonCodeSet = baseCodesSet ?? new Set(allFresh.map((p) => p.code));
+
+  // Any mismatch means a transfer happened — do not restore.
+  if (
+    comparisonCodeSet.size !== stored.fingerprint.length ||
+    stored.fingerprint.some((code) => !comparisonCodeSet.has(code))
+  ) {
+    return null;
+  }
+
+  const playerMap = Object.fromEntries(allFresh.map((p) => [p.code, p]));
+
+  // Derive base points for captain multiplier (undo any existing 2× multiplier).
+  const getBase = (p) =>
+    p.basePoints != null
+      ? p.basePoints
+      : Math.round((p.predictedPoints ?? 0) / (p.multiplier || 1));
+
+  const newActive = stored.activePlayerCodes
+    .map(({ code, slot }) => {
+      const p = playerMap[code];
+      if (!p) return null;
+      const isCapt = code === stored.captainCode;
+      const isVC   = code === stored.viceCaptainCode;
+      const base   = getBase(p);
+      return {
+        ...p,
+        isActive: true,
+        slot,
+        is_captain: isCapt,
+        is_vice_captain: isVC,
+        multiplier: isCapt ? 2 : 1,
+        basePoints: base,
+        predictedPoints: isCapt ? base * 2 : base,
+      };
+    })
+    .filter(Boolean);
+
+  const newReserve = stored.reservePlayerCodes
+    .map(({ code, slot }) => {
+      const p = playerMap[code];
+      if (!p) return null;
+      const isVC = code === stored.viceCaptainCode;
+      return {
+        ...p,
+        isActive: false,
+        slot,
+        is_captain: false,
+        is_vice_captain: isVC,
+        multiplier: 1,
+      };
+    })
+    .filter(Boolean);
+
+  // Only return a valid result if every expected player was found.
+  if (
+    newActive.length !== stored.activePlayerCodes.length ||
+    newReserve.length !== stored.reservePlayerCodes.length
+  ) {
+    return null;
+  }
+
+  return { activePlayers: newActive, reservePlayers: newReserve };
+}


### PR DESCRIPTION
This pull request adds robust support for planning and displaying Free Hit chip usage across future gameweeks, ensuring that squad, transfer, and bank calculations properly account for the temporary nature of Free Hit transfers. It also improves the persistence and restoration of planned chip and lineup state, and enhances the UI to clearly indicate when a Free Hit is active. The changes touch core logic in `App.jsx`, transfer display components, and team data management.

**Free Hit chip logic and state management:**

* Introduced `plannedChipsByGW` state in `App.jsx` to persistently track planned chip usage (including Free Hit) per gameweek, loading from and saving to local storage. This ensures chip plans survive page refreshes and team switches. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L49-R69) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L102-R175)
* Added logic to compute `freeHitGWs` (set of GWs with planned Free Hit chip) and consistently pass it to relevant components for accurate transfer and squad handling. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L102-R175) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R754) [[3]](diffhunk://#diff-df7bbb0f5ddd9f8c121e1ca4aa1d129b0de1646a52199613af170141b94de821R22) [[4]](diffhunk://#diff-df7bbb0f5ddd9f8c121e1ca4aa1d129b0de1646a52199613af170141b94de821R296) [[5]](diffhunk://#diff-df7bbb0f5ddd9f8c121e1ca4aa1d129b0de1646a52199613af170141b94de821R333) [[6]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R328) [[7]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R589)

**Correct handling of Free Hit in transfer/squad simulation:**

* Updated transfer application logic so that transfers made in a Free Hit week are only applied when viewing that specific GW, and do not carry forward to subsequent GWs or affect squad composition, club limits, or free transfer carryover. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L170-R252) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L198-R269) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R282-R311) [[4]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L234-R333) [[5]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L300-R401) [[6]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R478-R480)

**UI improvements for Free Hit awareness:**

* Enhanced `PlannedTransfers` and `TeamActivityPanel` to visually mark transfers in Free Hit gameweeks with a "Free Hit" chip and explanatory tooltip, improving user clarity. [[1]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R377) [[2]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R391-R399) [[3]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R488) [[4]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R509-R517) [[5]](diffhunk://#diff-df7bbb0f5ddd9f8c121e1ca4aa1d129b0de1646a52199613af170141b94de821R296)

**Persistence and restoration of user choices:**

* Improved chip and lineup restoration logic to ensure planned chips and custom lineups are reliably restored only when appropriate (e.g., when the squad fingerprint matches), preventing stale or invalid state after transfers or chip usage. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L102-R175) [[2]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR23-R30) [[3]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR52) [[4]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR86-R112)

**Codebase maintainability:**

* Refactored and documented state and effect hooks, and updated prop types to reflect new state and props, improving code clarity and future extensibility. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L49-R69) [[2]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R589) [[3]](diffhunk://#diff-df7bbb0f5ddd9f8c121e1ca4aa1d129b0de1646a52199613af170141b94de821R333) [[4]](diffhunk://#diff-655de3fac542fbb9560e43c3f9b9ed44c1520bb0606024b250b4676cff16487aR23-R30)

These changes together ensure the Free Hit chip is handled correctly both in logic and in the user interface, making future planning more reliable and intuitive.