### PR TITLE
Add vertical divider between bench GK and outfield players in TeamFormation

### DIFF
--- a/frontend/src/components/TeamFormation/TeamFormation.jsx
+++ b/frontend/src/components/TeamFormation/TeamFormation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Paper, Typography } from '@mui/material';
+import { Box, Divider, Paper, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import PropTypes from 'prop-types';
 import PlayerCard from '../PlayerCard/PlayerCard';
@@ -242,6 +242,10 @@ const TeamFormation = ({ activePlayers, reservePlayers, selectedPlayer, team, al
                     />
                   </Box>
                 </Grid>
+              ) }
+              { /* Vertical separator between bench GK and outfield */ }
+              { benchGK && benchOutfield.length > 0 && (
+                <Divider orientation='vertical' flexItem sx={ { mx: 0.5, alignSelf: 'center', height: 80 } } />
               ) }
               { /* Outfield bench players */ }
               { benchOutfield.map((player) => (

--- a/frontend/src/components/TeamListView/TeamListView.jsx
+++ b/frontend/src/components/TeamListView/TeamListView.jsx
@@ -334,7 +334,14 @@ const TeamListView = ({
   const captain = activePlayers?.length ? activePlayers.find(p => p.is_captain) ?? null : null;
   const sortByPosition = (arr) => [...arr].sort((a, b) => (POSITION_SORT_ORDER[a.position] ?? 9) - (POSITION_SORT_ORDER[b.position] ?? 9));
   const activeList = sortByPosition(activePlayers ?? []);
-  const reserveList = sortByPosition(reservePlayers ?? []);
+  const reserveList = (() => {
+    const bench = reservePlayers ?? [];
+    const gk = bench.filter(p => p.position === POSITION_GK);
+    const outfield = bench.filter(p => p.position !== POSITION_GK && p.position !== POSITION_MANAGER)
+      .sort((a, b) => (parseFloat(b.predictedPoints) || 0) - (parseFloat(a.predictedPoints) || 0));
+    const manager = bench.filter(p => p.position === POSITION_MANAGER);
+    return [...manager, ...gk, ...outfield];
+  })();
 
   const sharedRowProps = {
     selectedPlayer, team, allPlayers, onTransfer, onPlayerClick,
@@ -375,18 +382,30 @@ const TeamListView = ({
             </TableCell>
           </TableRow>
 
-          { reserveList.map((player) => (
-            <ListRow
-              key={ player.code ?? player.webName }
-              player={ player }
-              isCaptain={ false }
-              teamType='reserve'
-              activePlayers={ activePlayers }
-              reservePlayers={ reservePlayers }
-              onSetCaptain={ undefined }
-              { ...sharedRowProps }
-            />
-          )) }
+          { reserveList.map((player, idx) => {
+            const prevPlayer = reserveList[idx - 1];
+            const showSeparator = idx > 0 && prevPlayer?.position === POSITION_GK && player.position !== POSITION_GK;
+            return (
+              <React.Fragment key={ player.code ?? player.webName }>
+                { showSeparator && (
+                  <TableRow>
+                    <TableCell colSpan={ 7 } sx={ { p: 0, border: 'none' } }>
+                      <Box sx={ { borderTop: '2px solid', borderTopColor: 'divider', mx: 1 } } />
+                    </TableCell>
+                  </TableRow>
+                ) }
+                <ListRow
+                  player={ player }
+                  isCaptain={ false }
+                  teamType='reserve'
+                  activePlayers={ activePlayers }
+                  reservePlayers={ reservePlayers }
+                  onSetCaptain={ undefined }
+                  { ...sharedRowProps }
+                />
+              </React.Fragment>
+            );
+          }) }
         </TableBody>
       </Table>
     </Paper>


### PR DESCRIPTION
This pull request improves the visual separation and organization of bench (reserve) players in both the `TeamFormation` and `TeamListView` components. The changes introduce visual dividers between goalkeepers (GK) and outfield players on the bench, and adjust the sorting logic for reserve players to group managers, goalkeepers, and outfield players more intuitively.

**Bench Player Display Improvements:**

* Added a vertical `Divider` between the bench goalkeeper and outfield players in the `TeamFormation` component for clearer visual separation. [[1]](diffhunk://#diff-0726b4930de88cb9a3245595e12d484aabb3d4275b046f7e52e27fc8a5c8aa14L2-R2) [[2]](diffhunk://#diff-0726b4930de88cb9a3245595e12d484aabb3d4275b046f7e52e27fc8a5c8aa14R246-R249)
* In `TeamListView`, added a horizontal separator row after the bench goalkeeper and before the outfield players in the reserve list table. [[1]](diffhunk://#diff-909b494dddf52a7e3926a9016b636cdd215bd5bf3b926737ca4629ee7242c098L378-L380) [[2]](diffhunk://#diff-909b494dddf52a7e3926a9016b636cdd215bd5bf3b926737ca4629ee7242c098L389-R408)

**Bench Player Sorting Logic:**

* Updated the reserve player sorting in `TeamListView` to group managers first, then goalkeepers, followed by outfield players (sorted by predicted points descending), improving clarity and usability.