### PR TITLE
Enhance points display logic in ListRow component for live and finished matches

### DIFF
--- a/frontend/src/components/TeamListView/TeamListView.jsx
+++ b/frontend/src/components/TeamListView/TeamListView.jsx
@@ -62,6 +62,25 @@ const ListRow = ({
 
   const predictedPoints = parseFloat(player.predictedPoints) || 0;
   const kickoff = formatKickoff(player.fixtureKickoff);
+
+  // Determine points display state
+  const anyStarted  = player.opponents?.some(o => o.started)  ?? false;
+  const allFinished = (player.opponents?.length > 0) && (player.opponents?.every(o => o.finished) ?? false);
+  const isMatchLive = anyStarted && !allFinished;
+  const isMatchDone = allFinished;
+  const hasActual   = player.gameweekStats?.points != null;
+
+  let displayPoints, pointsColor;
+  if (isMatchDone && hasActual) {
+    displayPoints = player.gameweekStats.points;
+    pointsColor   = 'success.main';
+  } else if (isMatchLive && hasActual) {
+    displayPoints = player.gameweekStats.points;
+    pointsColor   = 'warning.main';
+  } else {
+    displayPoints = predictedPoints;
+    pointsColor   = 'info.main';
+  }
   const espnMatch = liveMatches?.find(m =>
     teamsMatch(player.teamName, m.homeName) || teamsMatch(player.teamName, m.awayName)
   ) ?? null;
@@ -163,8 +182,8 @@ const ListRow = ({
 
         { /* POINTS */ }
         <TableCell sx={ cellSx } align='right'>
-          <Typography variant='body2' fontWeight='bold' color='secondary' noWrap>
-            { predictedPoints }
+          <Typography variant='body2' fontWeight='bold' sx={ { color: pointsColor } } noWrap>
+            { displayPoints }
           </Typography>
         </TableCell>
 
@@ -470,6 +489,7 @@ ListRow.propTypes = {
     fixtureKickoff: PropTypes.string,
     difficulty: PropTypes.number,
     teamName: PropTypes.string,
+    gameweekStats: PropTypes.shape({ points: PropTypes.number }),
   }).isRequired,
   isCaptain: PropTypes.bool,
   teamType: PropTypes.string,


### PR DESCRIPTION
This pull request updates the points display logic in the `TeamListView` component to more accurately reflect player match status and actual points. Instead of always showing predicted points, the UI now dynamically shows actual points with contextual coloring based on whether a match is live, finished, or upcoming.

**Improvements to points display logic:**

* The points column now shows actual points if available, using a green color when the match is finished and an orange color when the match is live; otherwise, it shows predicted points in blue. This makes it easier for users to distinguish between finalized, live, and projected scores. [[1]](diffhunk://#diff-909b494dddf52a7e3926a9016b636cdd215bd5bf3b926737ca4629ee7242c098R65-R83) [[2]](diffhunk://#diff-909b494dddf52a7e3926a9016b636cdd215bd5bf3b926737ca4629ee7242c098L166-R186)

**Prop types update:**

* The `player` prop type now includes a `gameweekStats` shape with a `points` field to support the new display logic.