### PR TITLE
Add assist information to event parsing and update EventRow display

### DIFF
--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -195,6 +195,30 @@ const getFixtures = async (req, res) => {
       filtered = fixtures.filter(f => f.event === gw);
     }
 
+    const elementsById = {};
+    (bootstrap.elements || []).forEach(e => { elementsById[e.id] = e; });
+
+    const enrichStats = (stats) => {
+      if (!stats?.length) return [];
+      return stats
+        .filter(s => s.identifier === 'goals_scored' || s.identifier === 'assists')
+        .map(s => ({
+          identifier: s.identifier,
+          h: (s.h || []).map(entry => ({
+            element: entry.element,
+            value: entry.value,
+            webName: elementsById[entry.element]?.web_name || '',
+            shortName: elementsById[entry.element]?.web_name || '',
+          })),
+          a: (s.a || []).map(entry => ({
+            element: entry.element,
+            value: entry.value,
+            webName: elementsById[entry.element]?.web_name || '',
+            shortName: elementsById[entry.element]?.web_name || '',
+          })),
+        }));
+    };
+
     const result = filtered.map(f => ({
       id: f.id,
       event: f.event,
@@ -209,6 +233,7 @@ const getFixtures = async (req, res) => {
       team_a_name: teamsById[f.team_a]?.name || '',
       team_h_short: teamsById[f.team_h]?.short_name || '',
       team_a_short: teamsById[f.team_a]?.short_name || '',
+      stats: enrichStats(f.stats),
     }));
 
     res.json(result);

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -15,6 +15,8 @@ import { useTheme } from '@mui/material/styles';
 import axios from '../../api';
 import { teamsMatch, parseMatch, espnScoreboardUrl } from '../../hooks/useLiveScores';
 
+const ESPN_SUMMARY_URL = (eventId) => `https://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/summary?event=${eventId}`;
+
 const formatDateHeader = (date) =>
   date.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' });
 
@@ -108,16 +110,9 @@ const EventRow = ({ event, homeId, homeAbbr, awayAbbr }) => {
       <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
         { iconNode }
       </Box>
-      <Box sx={ { flex: 1, overflow: 'hidden' } }>
-        <Typography variant='caption' sx={ { color: 'text.primary' } } noWrap>
-          { event.player || '—' }{ nameSuffix }
-        </Typography>
-        { event.icon === 'goal' && event.assist && (
-          <Typography variant='caption' sx={ { color: 'text.disabled', display: 'block' } } noWrap>
-            🅰 { event.assist }
-          </Typography>
-        ) }
-      </Box>
+      <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+        { event.player || '—' }{ nameSuffix }
+      </Typography>
       <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
         { abbr }
       </Typography>
@@ -134,7 +129,7 @@ EventRow.propTypes = {
 
 // ─── Single fixture row (collapsible) ────────────────────────────────────────
 
-const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme }) => {
+const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme, assisters }) => {
   const isFinished   = fixture.finished;
   const isStarted    = fixture.started;
   const fplHomeScore = fixture.team_h_score;
@@ -154,7 +149,7 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme }) => {
   const isLive    = hasEspn ? espnMatch.isLive : (!isFinished && isStarted);
   const isOver    = hasEspn ? espnMatch.isFinished : isFinished;
   const clock     = (!isOver && hasEspn) ? espnMatch.clock : null;
-  const hasEvents = hasEspn && (isLive || espnMatch.details.some(d => d.icon !== 'other'));
+  const hasEvents = (hasEspn && (isLive || espnMatch.details.some(d => d.icon !== 'other'))) || assisters?.length > 0;
 
   const teamNameSx = { flex: 1, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 
@@ -248,7 +243,7 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme }) => {
                 sx={ { mb: 0.75, height: 18, fontSize: '0.6rem', fontWeight: 700 } }
               />
             ) }
-            { espnMatch.details
+            { espnMatch?.details
                 .filter(d => d.icon !== 'other')
                 .map((event, idx) => (
                   <EventRow
@@ -260,6 +255,24 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme }) => {
                   />
                 ))
             }
+            { assisters?.length > 0 && (
+              <Box sx={ { mt: espnMatch?.details?.some(d => d.icon !== 'other') ? 0.5 : 0 } }>
+                { assisters.map((a, idx) => (
+                  <Box key={ idx } sx={ { display: 'flex', alignItems: 'center', gap: 0.75, py: '2px' } }>
+                    <Typography variant='caption' sx={ { color: 'text.disabled', minWidth: 34, flexShrink: 0 } } />
+                    <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
+                      <Typography component='span' variant='caption' sx={ { flexShrink: 0 } }>🅰️</Typography>
+                    </Box>
+                    <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+                      { a.name }{ a.value > 1 ? ` ×${a.value}` : '' }
+                    </Typography>
+                    <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
+                      { a.abbr }
+                    </Typography>
+                  </Box>
+                )) }
+              </Box>
+            ) }
           </Box>
         </Collapse>
       ) }
@@ -270,6 +283,7 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme }) => {
 FixtureRow.propTypes = {
   fixture:   PropTypes.object.isRequired,
   espnMatch: PropTypes.object,
+  assisters: PropTypes.array,
   expanded:  PropTypes.bool,
   onToggle:  PropTypes.func,
   theme:     PropTypes.object.isRequired,
@@ -284,14 +298,18 @@ const FixturesPanel = ({ gameweek, deadline, liveMatches }) => {
   const [error, setError]             = useState(null);
   const [expandedId, setExpandedId]   = useState(null);
   const [historicalMatches, setHistoricalMatches] = useState([]);
-  const fetchedDatesRef = useRef(new Set());
+  const [summaryAssistersMap, setSummaryAssistersMap] = useState({}); // espnId -> [{name, abbr, value}]
+  const fetchedDatesRef    = useRef(new Set());
+  const fetchedSummaryRef  = useRef(new Set());
 
   const deadlinePill = getDeadlinePill(deadline, theme);
 
   // Reset historical cache whenever the displayed gameweek changes.
   useEffect(() => {
     fetchedDatesRef.current = new Set();
+    fetchedSummaryRef.current = new Set();
     setHistoricalMatches([]);
+    setSummaryAssistersMap({});
   }, [gameweek]);
 
   useEffect(() => {
@@ -340,6 +358,55 @@ const FixturesPanel = ({ gameweek, deadline, liveMatches }) => {
     () => [...(liveMatches ?? []), ...historicalMatches],
     [liveMatches, historicalMatches]
   );
+
+  // When a fixture is expanded, fetch the ESPN summary to get assister names.
+  // Falls back to enriched FPL fixture stats when no ESPN match is available.
+  useEffect(() => {
+    if (!expandedId) return;
+    const fixture   = fixtures.find(f => f.id === expandedId);
+    if (!fixture) return;
+    const espnMatch = findEspnMatch(fixture, allEspnMatches);
+
+    if (espnMatch?.espnId) {
+      // ── ESPN primary ────────────────────────────────────────────────────────
+      if (fetchedSummaryRef.current.has(espnMatch.espnId)) return;
+      fetchedSummaryRef.current.add(espnMatch.espnId);
+      let cancelled = false;
+      fetch(ESPN_SUMMARY_URL(espnMatch.espnId))
+        .then(r => r.json())
+        .then(data => {
+          if (cancelled) return;
+          const assisters = [];
+          for (const team of data.rosters ?? []) {
+            const abbr = team.team?.abbreviation ?? '';
+            for (const ath of team.roster ?? []) {
+              const gaStat = (ath.stats ?? []).find(s => s.name === 'goalAssists');
+              const gaVal  = parseFloat(gaStat?.value ?? 0);
+              if (gaVal > 0) {
+                assisters.push({
+                  name:  ath.athlete?.shortName ?? ath.athlete?.displayName ?? '',
+                  abbr,
+                  value: gaVal,
+                });
+              }
+            }
+          }
+          setSummaryAssistersMap(prev => ({ ...prev, [espnMatch.espnId]: assisters }));
+        })
+        .catch(() => {});
+      return () => { cancelled = true; };
+    } else {
+      // ── FPL fallback ─────────────────────────────────────────────────────────
+      const assistStat = fixture.stats?.find(s => s.identifier === 'assists');
+      if (!assistStat) return;
+      const assisters = [
+        ...(assistStat.h || []).map(e => ({ name: e.webName, abbr: fixture.team_h_short, value: e.value })),
+        ...(assistStat.a || []).map(e => ({ name: e.webName, abbr: fixture.team_a_short, value: e.value })),
+      ].filter(a => a.name && a.value > 0);
+      // Store under a synthetic key for FPL-only fixtures
+      setSummaryAssistersMap(prev => ({ ...prev, [`fpl-${fixture.id}`]: assisters }));
+    }
+  }, [expandedId, fixtures, allEspnMatches]);
 
   if (!gameweek) return null;
 
@@ -408,11 +475,14 @@ const FixturesPanel = ({ gameweek, deadline, liveMatches }) => {
 
           { dayFixtures.map((fixture) => {
             const espnMatch = findEspnMatch(fixture, allEspnMatches);
+            const assistKey = espnMatch?.espnId ?? `fpl-${fixture.id}`;
+            const assisters = summaryAssistersMap[assistKey] ?? null;
             return (
               <FixtureRow
                 key={ fixture.id }
                 fixture={ fixture }
                 espnMatch={ espnMatch }
+                assisters={ assisters }
                 expanded={ expandedId === fixture.id }
                 onToggle={ () => setExpandedId(prev => prev === fixture.id ? null : fixture.id) }
                 theme={ theme }

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -253,8 +253,8 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme, assisters }
             ) }
             { (() => {
               // Build per-team assister queues so each goal consumes the next available assister.
-              const homeQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.homeAbbr).flatMap(a => Array(a.value).fill(a.name));
-              const awayQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.awayAbbr).flatMap(a => Array(a.value).fill(a.name));
+              const homeQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.homeAbbr).flatMap(a => Array(Math.trunc(a.value)).fill(a.name));
+              const awayQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.awayAbbr).flatMap(a => Array(Math.trunc(a.value)).fill(a.name));
               return espnMatch?.details
                 .filter(d => d.icon !== 'other')
                 .map((event, idx) => {
@@ -279,7 +279,8 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme, assisters }
               <Box key={ idx } sx={ { display: 'flex', alignItems: 'center', gap: 0.75, py: '2px' } }>
                 <Typography variant='caption' sx={ { color: 'text.disabled', minWidth: 34, flexShrink: 0 } } />
                 <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
-                  <Typography component='span' variant='caption'>🅰️</Typography>
+                  <Typography component='span' variant='caption' aria-hidden='true'>🅰️</Typography>
+                  <Box component='span' sx={ { position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap' } }>Assist:</Box>
                 </Box>
                 <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
                   { a.name }{ a.value > 1 ? ` ×${a.value}` : '' }
@@ -386,7 +387,6 @@ const FixturesPanel = ({ gameweek, deadline, liveMatches }) => {
     if (espnMatch?.espnId) {
       // ── ESPN primary ────────────────────────────────────────────────────────
       if (fetchedSummaryRef.current.has(espnMatch.espnId)) return;
-      fetchedSummaryRef.current.add(espnMatch.espnId);
       let cancelled = false;
       fetch(ESPN_SUMMARY_URL(espnMatch.espnId))
         .then(r => r.json())
@@ -407,6 +407,7 @@ const FixturesPanel = ({ gameweek, deadline, liveMatches }) => {
               }
             }
           }
+          fetchedSummaryRef.current.add(espnMatch.espnId);
           setSummaryAssistersMap(prev => ({ ...prev, [espnMatch.espnId]: assisters }));
         })
         .catch(() => {});

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -108,9 +108,16 @@ const EventRow = ({ event, homeId, homeAbbr, awayAbbr }) => {
       <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
         { iconNode }
       </Box>
-      <Typography variant='caption' sx={ { flex: 1, color: 'text.primary' } } noWrap>
-        { event.player || '—' }{ nameSuffix }
-      </Typography>
+      <Box sx={ { flex: 1, overflow: 'hidden' } }>
+        <Typography variant='caption' sx={ { color: 'text.primary' } } noWrap>
+          { event.player || '—' }{ nameSuffix }
+        </Typography>
+        { event.icon === 'goal' && event.assist && (
+          <Typography variant='caption' sx={ { color: 'text.disabled', display: 'block' } } noWrap>
+            🅰 { event.assist }
+          </Typography>
+        ) }
+      </Box>
       <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
         { abbr }
       </Typography>

--- a/frontend/src/components/FixturesPanel/FixturesPanel.jsx
+++ b/frontend/src/components/FixturesPanel/FixturesPanel.jsx
@@ -78,7 +78,7 @@ CardBox.propTypes = { color: PropTypes.string.isRequired };
 
 // ─── Single event row inside the expanded section ────────────────────────────
 
-const EventRow = ({ event, homeId, homeAbbr, awayAbbr }) => {
+const EventRow = ({ event, homeId, homeAbbr, awayAbbr, assist }) => {
   const isHome = event.teamId === homeId;
   const abbr   = isHome ? homeAbbr : awayAbbr;
 
@@ -100,7 +100,7 @@ const EventRow = ({ event, homeId, homeAbbr, awayAbbr }) => {
   }
 
   return (
-    <Box sx={ { display: 'flex', alignItems: 'center', gap: 0.75, py: '2px' } }>
+    <Box sx={ { display: 'flex', alignItems: 'flex-start', gap: 0.75, py: '2px' } }>
       <Typography
         variant='caption'
         sx={ { color: 'text.disabled', minWidth: 34, flexShrink: 0, fontVariantNumeric: 'tabular-nums' } }
@@ -110,9 +110,16 @@ const EventRow = ({ event, homeId, homeAbbr, awayAbbr }) => {
       <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
         { iconNode }
       </Box>
-      <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
-        { event.player || '—' }{ nameSuffix }
-      </Typography>
+      <Box sx={ { flex: 1, overflow: 'hidden' } }>
+        <Typography variant='caption' sx={ { color: 'text.primary', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+          { event.player || '—' }{ nameSuffix }
+        </Typography>
+        { assist && (
+          <Typography variant='caption' sx={ { color: 'text.primary', display: 'block', pl: 1.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+            Assist: { assist }
+          </Typography>
+        ) }
+      </Box>
       <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
         { abbr }
       </Typography>
@@ -125,6 +132,7 @@ EventRow.propTypes = {
   homeId:   PropTypes.string,
   homeAbbr: PropTypes.string,
   awayAbbr: PropTypes.string,
+  assist:   PropTypes.string,
 };
 
 // ─── Single fixture row (collapsible) ────────────────────────────────────────
@@ -243,36 +251,44 @@ const FixtureRow = ({ fixture, espnMatch, expanded, onToggle, theme, assisters }
                 sx={ { mb: 0.75, height: 18, fontSize: '0.6rem', fontWeight: 700 } }
               />
             ) }
-            { espnMatch?.details
+            { (() => {
+              // Build per-team assister queues so each goal consumes the next available assister.
+              const homeQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.homeAbbr).flatMap(a => Array(a.value).fill(a.name));
+              const awayQueue = (assisters ?? []).filter(a => a.abbr === espnMatch?.awayAbbr).flatMap(a => Array(a.value).fill(a.name));
+              return espnMatch?.details
                 .filter(d => d.icon !== 'other')
-                .map((event, idx) => (
-                  <EventRow
-                    key={ `${event.minute ?? ''}-${event.teamId ?? ''}-${event.player ?? ''}-${event.icon}-${idx}` }
-                    event={ event }
-                    homeId={ espnMatch.homeId }
-                    homeAbbr={ espnMatch.homeAbbr }
-                    awayAbbr={ espnMatch.awayAbbr }
-                  />
-                ))
-            }
-            { assisters?.length > 0 && (
-              <Box sx={ { mt: espnMatch?.details?.some(d => d.icon !== 'other') ? 0.5 : 0 } }>
-                { assisters.map((a, idx) => (
-                  <Box key={ idx } sx={ { display: 'flex', alignItems: 'center', gap: 0.75, py: '2px' } }>
-                    <Typography variant='caption' sx={ { color: 'text.disabled', minWidth: 34, flexShrink: 0 } } />
-                    <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
-                      <Typography component='span' variant='caption' sx={ { flexShrink: 0 } }>🅰️</Typography>
-                    </Box>
-                    <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
-                      { a.name }{ a.value > 1 ? ` ×${a.value}` : '' }
-                    </Typography>
-                    <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
-                      { a.abbr }
-                    </Typography>
-                  </Box>
-                )) }
+                .map((event, idx) => {
+                  let assist = undefined;
+                  if (event.icon === 'goal' && !event.ownGoal && !event.penaltyKick) {
+                    const isHome = event.teamId === espnMatch.homeId;
+                    assist = isHome ? homeQueue.shift() : awayQueue.shift();
+                  }
+                  return (
+                    <EventRow
+                      key={ `${event.minute ?? ''}-${event.teamId ?? ''}-${event.player ?? ''}-${event.icon}-${idx}` }
+                      event={ event }
+                      homeId={ espnMatch.homeId }
+                      homeAbbr={ espnMatch.homeAbbr }
+                      awayAbbr={ espnMatch.awayAbbr }
+                      assist={ assist }
+                    />
+                  );
+                });
+            })() }
+            { !espnMatch && assisters?.length > 0 && assisters.map((a, idx) => (
+              <Box key={ idx } sx={ { display: 'flex', alignItems: 'center', gap: 0.75, py: '2px' } }>
+                <Typography variant='caption' sx={ { color: 'text.disabled', minWidth: 34, flexShrink: 0 } } />
+                <Box sx={ { width: 18, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' } }>
+                  <Typography component='span' variant='caption'>🅰️</Typography>
+                </Box>
+                <Typography variant='caption' sx={ { flex: 1, color: 'text.primary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }>
+                  { a.name }{ a.value > 1 ? ` ×${a.value}` : '' }
+                </Typography>
+                <Typography variant='caption' sx={ { color: 'text.secondary', flexShrink: 0 } }>
+                  { a.abbr }
+                </Typography>
               </Box>
-            ) }
+            )) }
           </Box>
         </Collapse>
       ) }

--- a/frontend/src/components/PlayerStatsDialog/PlayerStatsDialog.jsx
+++ b/frontend/src/components/PlayerStatsDialog/PlayerStatsDialog.jsx
@@ -101,9 +101,11 @@ const buildBreakdown = (entry, position, { provisionalBonus = null } = {}) => {
     rows.push({ identifier: 'saves', value: entry.saves, points: Math.floor(entry.saves / 3) });
   }
 
-  // Defensive contribution — 2 pts per 12 contributions (threshold-based)
+  // Defensive contribution — 2 pts when threshold reached:
+  // GK/DEF: 10+ CBI+tackles; MID/FWD: 12+ CBI+tackles+recoveries
   if (entry.defensive_contribution > 0) {
-    const dcPts = Math.floor(entry.defensive_contribution / 12) * 2;
+    const dcThreshold = (position === 1 || position === 2) ? 10 : 12;
+    const dcPts = entry.defensive_contribution >= dcThreshold ? 2 : 0;
     rows.push({ identifier: 'defensive_contribution', value: entry.defensive_contribution, points: dcPts, provisional: false });
   }
 

--- a/frontend/src/hooks/useLiveScores.js
+++ b/frontend/src/hooks/useLiveScores.js
@@ -46,7 +46,6 @@ export const parseMatch = (event) => {
       minute:      d.clock?.displayValue ?? '',
       teamId:      d.team?.id,
       player:      d.athletesInvolved?.[0]?.shortName ?? '',
-      assist:      d.athletesInvolved?.[1]?.shortName ?? '',
       penaltyKick: d.penaltyKick ?? false,
       ownGoal:     d.ownGoal ?? false,
     };

--- a/frontend/src/hooks/useLiveScores.js
+++ b/frontend/src/hooks/useLiveScores.js
@@ -46,6 +46,7 @@ export const parseMatch = (event) => {
       minute:      d.clock?.displayValue ?? '',
       teamId:      d.team?.id,
       player:      d.athletesInvolved?.[0]?.shortName ?? '',
+      assist:      d.athletesInvolved?.[1]?.shortName ?? '',
       penaltyKick: d.penaltyKick ?? false,
       ownGoal:     d.ownGoal ?? false,
     };


### PR DESCRIPTION
This pull request enhances the display of football match events by adding assist information to the event rows in the fixtures panel. It also updates the data parsing logic to include assist details when available.

**UI improvements:**

* The `FixturesPanel` now displays the assist player's name (if available) under the scorer's name for goal events, with a distinct style and an assist icon.

**Data handling:**

* The `parseMatch` function in `useLiveScores.js` now extracts the assist player's name from the event data, making it available for UI components.