### PR TITLE
Enhance league UI with live points tracking and improved selection

### DIFF
--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -541,7 +541,7 @@ const getUserTeamForEntry = async (req, res) => {
     const isPastGameweek = !!(targetEventData && targetEventData.finished);
     const isActiveGameweek = !!(targetEventData && targetEventData.is_current && !targetEventData.finished);
 
-    if (isPastGameweek || isActiveGameweek) {
+    if (isPastGameweek || -isActiveGameweek) {
       players = await fplModel.enrichPlayersWithGameweekStats(players, targetEvent);
     }
 
@@ -1130,6 +1130,7 @@ const getLeagueStandings = async (req, res) => {
     ]);
 
     const currentEvent = bootstrap.events.find(e => e.is_current) || bootstrap.events[0];
+    const isActiveGw = !!currentEvent.is_current && !currentEvent.finished;
 
     // Build base player list enriched with predicted points
     let allPlayers = bootstrap.elements.map(p => ({
@@ -1137,31 +1138,60 @@ const getLeagueStandings = async (req, res) => {
       ep_next: parseFloat(p.ep_next) || 0,
     }));
 
-    // Pre-compute per-player cumulative predicted points map
+    // Pre-compute per-player cumulative predicted points map (future GWs)
     const playerPointsMap = buildPlayerPointsMap(
       allPlayers, fixtures, bootstrap.teams, currentEvent.id, gameweeksAhead
     );
 
-    const entries = standingsData.standings?.results || [];
+    // Fetch live GW data in parallel with team picks.
+    // The FPL live endpoint updates in near-real-time during matches, so we use
+    // it to compute each team's live GW score rather than relying on the
+    // standings endpoint which only refreshes at end-of-day.
+    const [liveGwData, picksResults] = await Promise.all([
+      fplModel.fetchLiveGameweek(currentEvent.id).catch(() => null),
+      Promise.allSettled(
+        (standingsData.standings?.results || []).map(entry =>
+          fplModel.fetchPlayerPicks(entry.entry, currentEvent.id)
+        )
+      ),
+    ]);
 
-    // Fetch picks for all entries in parallel
-    const picksResults = await Promise.allSettled(
-      entries.map(entry => fplModel.fetchPlayerPicks(entry.entry, currentEvent.id))
-    );
+    // Build map of elementId → live total_points from FPL live endpoint
+    const livePointsMap = {};
+    if (liveGwData?.elements) {
+      liveGwData.elements.forEach(el => {
+        livePointsMap[el.id] = el.stats?.total_points ?? 0;
+      });
+    }
+
+    const entries = standingsData.standings?.results || [];
 
     const standingsWithPredictions = entries.map((entry, i) => {
       let predictedPoints = null;
+      let livePoints = null;
       const picksResult = picksResults[i];
       if (picksResult.status === 'fulfilled' && picksResult.value?.picks) {
-        // Sum predicted points for starting 11 only (bench players have multiplier 0)
-        predictedPoints = picksResult.value.picks.reduce((sum, pick) => {
+        const picks = picksResult.value.picks;
+
+        // Future GW predictions (existing logic)
+        predictedPoints = picks.reduce((sum, pick) => {
           if (pick.multiplier <= 0) return sum;
           const pts = playerPointsMap[pick.element] || 0;
           return sum + pts * pick.multiplier;
         }, 0);
         predictedPoints = parseFloat(predictedPoints.toFixed(1));
+
+        // Live GW points — sum actual live points respecting captain multiplier
+        if (Object.keys(livePointsMap).length > 0) {
+          livePoints = picks.reduce((sum, pick) => {
+            if (pick.multiplier <= 0) return sum;
+            const pts = livePointsMap[pick.element] || 0;
+            return sum + pts * pick.multiplier;
+          }, 0);
+          livePoints = parseFloat(livePoints.toFixed(0));
+        }
       }
-      return { ...entry, predicted_points: predictedPoints };
+      return { ...entry, predicted_points: predictedPoints, live_points: livePoints };
     });
 
     res.json({
@@ -1171,6 +1201,7 @@ const getLeagueStandings = async (req, res) => {
         results: standingsWithPredictions,
       },
       currentGameweek: currentEvent.id,
+      isActiveGw,
       gameweeksAhead,
     });
   } catch (error) {

--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -541,7 +541,7 @@ const getUserTeamForEntry = async (req, res) => {
     const isPastGameweek = !!(targetEventData && targetEventData.finished);
     const isActiveGameweek = !!(targetEventData && targetEventData.is_current && !targetEventData.finished);
 
-    if (isPastGameweek || -isActiveGameweek) {
+    if (isPastGameweek || isActiveGameweek) {
       players = await fplModel.enrichPlayersWithGameweekStats(players, targetEvent);
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,7 +45,6 @@ const App = () => {
   const [teamView, setTeamView] = useState(() => localStorage.getItem('teamId') ? TEAM_VIEW.USER : TEAM_VIEW.HIGHEST);
   const [selectedGameweek, setSelectedGameweek] = useState(null); // null means current gameweek
   const [currentGameweek, setCurrentGameweek] = useState(null);
-  const [selectedLeague, setSelectedLeague] = useState(null); // invitation league drill-down
   const [viewingOpponentId, setViewingOpponentId] = useState(null); // opponent team being viewed
   const [pitchView, setPitchView] = useState(() => localStorage.getItem('pitchView') || 'formation'); // 'formation' | 'list'
   const [activeChip, setActiveChip] = useState(null); // 'bench_boost' | 'triple_captain' | 'free_hit' | 'wildcard' | null
@@ -733,13 +732,7 @@ const App = () => {
           <Box sx={ { flex: { xs: '1 1 auto', lg: '0 0 28%' }, width: { xs: '100%', lg: 'auto' }, display: 'flex', flexDirection: 'column', minHeight: { xs: 'auto', lg: '600px' } } }>
             <RightPanel
               entryId={ viewingOpponentId || currentEntryId }
-              onLeagueClick={ setSelectedLeague }
-              selectedLeague={ selectedLeague }
-              onBackFromLeague={ () => setSelectedLeague(null) }
-              onViewTeam={ (opponentEntryId) => {
-                handleViewOpponentTeam(opponentEntryId);
-                setSelectedLeague(null);
-              } }
+              onViewTeam={ handleViewOpponentTeam }
               currentGameweek={ currentGameweek }
               selectedGameweek={ selectedGameweek }
               viewingOpponentId={ viewingOpponentId }

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -61,8 +61,11 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
   const isActiveGw = standings?.isActiveGw ?? false;
 
   // Derived labels — notify parent so it can render the chip in its header
+  const predictedLabel = gameweeksAhead === 1
+    ? 'Predicted (Next GW)'
+    : `Predicted (Next ${gameweeksAhead} GWs)`;
   const gwModeLabel = isFuture
-    ? `Predicted (GW ${effectiveGW})`
+    ? predictedLabel
     : isPast
       ? `GW ${effectiveGW} Pts`
       : isActiveGw ? 'Live' : `GW ${effectiveGW} Pts`;
@@ -98,11 +101,10 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
             </TableHead>
             <TableBody>
               { standings.standings?.results?.map(entry => {
-                const gwPts = (!isFuture && entry.live_points != null)
+                const gwPts = (isActiveGw && entry.live_points != null)
                   ? entry.live_points
                   : entry.event_total;
                 const isMe = userEntryId && String(entry.entry) === String(userEntryId);
-                const isDark = theme.palette.mode === 'dark';
                 return (
                   <TableRow
                     key={ entry.id }

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -31,7 +31,7 @@ const getRankChangeIcon = (current, last, theme) => {
   return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 18, verticalAlign: 'middle' } } />;
 };
 
-const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGameweek, onModeChange }) => {
+const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGameweek, onModeChange, userEntryId }) => {
   const theme = useTheme();
   const [standings, setStandings] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -98,14 +98,20 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
             </TableHead>
             <TableBody>
               { standings.standings?.results?.map(entry => {
-                // For the active GW, use live_points (computed from live endpoint).
-                // For past GWs, live_points holds the confirmed final score.
-                // Fall back to event_total only if live data is unavailable.
                 const gwPts = (!isFuture && entry.live_points != null)
                   ? entry.live_points
                   : entry.event_total;
+                const isMe = userEntryId && String(entry.entry) === String(userEntryId);
                 return (
-                  <TableRow key={ entry.id } hover>
+                  <TableRow
+                    key={ entry.id }
+                    hover
+                    sx={ isMe ? {
+                      backgroundColor: theme.palette.primary.dark,
+                      '& .MuiTableCell-root': { color: '#fff', fontWeight: 600 },
+                      '&:hover .MuiTableCell-root': { backgroundColor: theme.palette.primary.main },
+                    } : {} }
+                  >
                     <TableCell>
                       { entry.rank }{ ' ' }
                       { getRankChangeIcon(entry.rank, entry.last_rank, theme) }
@@ -159,6 +165,7 @@ InvitationLeagueView.propTypes = {
   currentGameweek: PropTypes.number,
   selectedGameweek: PropTypes.number,
   onModeChange: PropTypes.func,
+  userEntryId: PropTypes.string,
 };
 
 export default InvitationLeagueView;

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -102,15 +102,12 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
                   ? entry.live_points
                   : entry.event_total;
                 const isMe = userEntryId && String(entry.entry) === String(userEntryId);
+                const isDark = theme.palette.mode === 'dark';
                 return (
                   <TableRow
                     key={ entry.id }
                     hover
-                    sx={ isMe ? {
-                      backgroundColor: theme.palette.primary.dark,
-                      '& .MuiTableCell-root': { color: '#fff', fontWeight: 600 },
-                      '&:hover .MuiTableCell-root': { backgroundColor: theme.palette.primary.main },
-                    } : {} }
+                    className={ isMe ? 'league-row-me' : '' }
                   >
                     <TableCell>
                       { entry.rank }{ ' ' }

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -9,8 +9,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  ToggleButton,
-  ToggleButtonGroup,
   Button,
   CircularProgress,
   Alert,
@@ -19,31 +17,38 @@ import {
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import RemoveIcon from '@mui/icons-material/Remove';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useTheme } from '@mui/material/styles';
 import axios from '../../api';
+import './styles.css';
 
-const getRankChangeIcon = (current, last) => {
+const getRankChangeIcon = (current, last, theme) => {
   if (last == null || current == null)
-    return <RemoveIcon sx={ { color: 'grey.500', fontSize: 18, verticalAlign: 'middle' } } />;
+    return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 18, verticalAlign: 'middle' } } />;
   if (last > current)
-    return <ArrowDropUpIcon sx={ { color: 'green', fontSize: 18, verticalAlign: 'middle' } } />;
+    return <ArrowDropUpIcon sx={ { color: theme.palette.success.main, fontSize: 18, verticalAlign: 'middle' } } />;
   if (last < current)
-    return <ArrowDropDownIcon sx={ { color: 'red', fontSize: 18, verticalAlign: 'middle' } } />;
-  return <RemoveIcon sx={ { color: 'grey.500', fontSize: 18, verticalAlign: 'middle' } } />;
+    return <ArrowDropDownIcon sx={ { color: theme.palette.error.main, fontSize: 18, verticalAlign: 'middle' } } />;
+  return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 18, verticalAlign: 'middle' } } />;
 };
 
-const InvitationLeagueView = ({ league, onBack, onViewTeam }) => {
-  const [gameweeksAhead, setGameweeksAhead] = useState(1);
+const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGameweek, onModeChange }) => {
+  const theme = useTheme();
   const [standings, setStandings] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const fetchStandings = useCallback(async (gwa) => {
+  // Derive display mode from selected vs current gameweek
+  const effectiveGW = selectedGameweek || currentGameweek;
+  const isFuture = currentGameweek != null && effectiveGW != null && effectiveGW > currentGameweek;
+  const isPast = currentGameweek != null && effectiveGW != null && effectiveGW < currentGameweek;
+  const gameweeksAhead = isFuture ? effectiveGW - currentGameweek : 1;
+
+  const fetchStandings = useCallback(async () => {
     setLoading(true);
     setError('');
     try {
       const res = await axios.get(
-        `/api/leagues-classic/${league.id}/standings?gameweeksAhead=${gwa}`
+        `/api/leagues-classic/${league.id}/standings?gameweeksAhead=${gameweeksAhead}`
       );
       setStandings(res.data);
     } catch (err) {
@@ -51,54 +56,28 @@ const InvitationLeagueView = ({ league, onBack, onViewTeam }) => {
     } finally {
       setLoading(false);
     }
-  }, [league.id]);
+  }, [league.id, gameweeksAhead]);
+
+  const isActiveGw = standings?.isActiveGw ?? false;
+
+  // Derived labels — notify parent so it can render the chip in its header
+  const gwModeLabel = isFuture
+    ? `Predicted (GW ${effectiveGW})`
+    : isPast
+      ? `GW ${effectiveGW} Pts`
+      : isActiveGw ? 'Live' : `GW ${effectiveGW} Pts`;
+  const gwModeColor = isFuture ? 'secondary' : (isPast || !isActiveGw) ? 'default' : 'success';
 
   useEffect(() => {
-    fetchStandings(gameweeksAhead);
-  }, [league.id, gameweeksAhead, fetchStandings]);
+    if (onModeChange) onModeChange({ label: gwModeLabel, color: gwModeColor, isFuture });
+  }, [gwModeLabel, gwModeColor, isFuture, onModeChange]);
 
-  const handleGwToggle = (_, value) => {
-    if (value !== null) setGameweeksAhead(value);
-  };
-
-  const predictedLabel = gameweeksAhead === 1
-    ? 'Predicted Pts (Next GW)'
-    : `Predicted Pts (Next ${gameweeksAhead} GWs)`;
+  useEffect(() => {
+    fetchStandings();
+  }, [fetchStandings]);
 
   return (
-    <Paper sx={ { p: 2 } }>
-      <Box sx={ { display: 'flex', alignItems: 'center', mb: 1 } }>
-        <Button
-          size='small'
-          startIcon={ <ArrowBackIcon /> }
-          onClick={ onBack }
-          sx={ { mr: 1 } }
-        >
-          Back
-        </Button>
-        <Typography variant='h6' component='span'>
-          { league.name }
-        </Typography>
-      </Box>
-
-      <Box sx={ { mb: 2 } }>
-        <Typography variant='body2' sx={ { mb: 0.5 } }>
-          Predicted points lookahead:
-        </Typography>
-        <ToggleButtonGroup
-          value={ gameweeksAhead }
-          exclusive
-          onChange={ handleGwToggle }
-          size='small'
-        >
-          <ToggleButton value={ 1 }>1 GW</ToggleButton>
-          <ToggleButton value={ 2 }>2 GWs</ToggleButton>
-          <ToggleButton value={ 3 }>3 GWs</ToggleButton>
-          <ToggleButton value={ 4 }>4 GWs</ToggleButton>
-          <ToggleButton value={ 5 }>5 GWs</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
-
+    <Paper className='league-view-pane' elevation={ 4 }>
       { error && <Alert severity='error' sx={ { mb: 1 } }>{ error }</Alert> }
 
       { loading ? (
@@ -114,38 +93,55 @@ const InvitationLeagueView = ({ league, onBack, onViewTeam }) => {
                 <TableCell>Team</TableCell>
                 <TableCell align='right'>GW Pts</TableCell>
                 <TableCell align='right'>Total</TableCell>
-                <TableCell align='right'>{ predictedLabel }</TableCell>
+                { isFuture && <TableCell align='right'>Predicted</TableCell> }
               </TableRow>
             </TableHead>
             <TableBody>
-              { standings.standings?.results?.map(entry => (
-                <TableRow key={ entry.id } hover>
-                  <TableCell>
-                    { entry.rank }{ ' ' }
-                    { getRankChangeIcon(entry.rank, entry.last_rank) }
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      size='small'
-                      variant='text'
-                      onClick={ () => onViewTeam(entry.entry, entry.entry_name) }
-                      sx={ { p: 0, minWidth: 0, textTransform: 'none', fontWeight: 'normal' } }
-                    >
-                      { entry.entry_name }
-                    </Button>
-                    <Typography variant='caption' display='block' color='text.secondary'>
-                      { entry.player_name }
-                    </Typography>
-                  </TableCell>
-                  <TableCell align='right'>{ entry.event_total }</TableCell>
-                  <TableCell align='right'>{ entry.total }</TableCell>
-                  <TableCell align='right'>
-                    { entry.predicted_points !== null && entry.predicted_points !== undefined
-                      ? entry.predicted_points
-                      : '–' }
-                  </TableCell>
-                </TableRow>
-              )) }
+              { standings.standings?.results?.map(entry => {
+                // For the active GW, use live_points (computed from live endpoint).
+                // For past GWs, live_points holds the confirmed final score.
+                // Fall back to event_total only if live data is unavailable.
+                const gwPts = (!isFuture && entry.live_points != null)
+                  ? entry.live_points
+                  : entry.event_total;
+                return (
+                  <TableRow key={ entry.id } hover>
+                    <TableCell>
+                      { entry.rank }{ ' ' }
+                      { getRankChangeIcon(entry.rank, entry.last_rank, theme) }
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size='small'
+                        variant='text'
+                        onClick={ () => onViewTeam(entry.entry, entry.entry_name) }
+                        sx={ {
+                          p: 0,
+                          minWidth: 0,
+                          textTransform: 'none',
+                          fontWeight: 'normal',
+                          textAlign: 'left',
+                          justifyContent: 'flex-start',
+                          color: 'inherit',
+                          '&:hover': { textDecoration: 'underline', background: 'none' },
+                        } }
+                      >
+                        { entry.entry_name }
+                      </Button>
+                      <Typography variant='caption' display='block' color='text.secondary'>
+                        { entry.player_name }
+                      </Typography>
+                    </TableCell>
+                    <TableCell align='right'>{ gwPts }</TableCell>
+                    <TableCell align='right'>{ entry.total }</TableCell>
+                    { isFuture && (
+                      <TableCell align='right'>
+                        { entry.predicted_points != null ? entry.predicted_points : '–' }
+                      </TableCell>
+                    ) }
+                  </TableRow>
+                );
+              }) }
             </TableBody>
           </Table>
         </TableContainer>
@@ -159,8 +155,10 @@ InvitationLeagueView.propTypes = {
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
   }).isRequired,
-  onBack: PropTypes.func.isRequired,
   onViewTeam: PropTypes.func.isRequired,
+  currentGameweek: PropTypes.number,
+  selectedGameweek: PropTypes.number,
+  onModeChange: PropTypes.func,
 };
 
 export default InvitationLeagueView;

--- a/frontend/src/components/InvitationLeagueView/styles.css
+++ b/frontend/src/components/InvitationLeagueView/styles.css
@@ -109,3 +109,36 @@ body.teletext-theme .MuiPaper-root.league-view-pane .MuiTableCell-head {
 body.teletext-theme .MuiPaper-root.league-view-pane .MuiTableRow-root:hover td {
   background: rgba(255, 255, 0, 0.1);
 }
+
+/* User row highlight — works across all themes */
+.MuiPaper-root.league-view-pane tr.league-row-me td {
+  background-color: #6a1b9a !important;
+  font-weight: 600;
+}
+.MuiPaper-root.league-view-pane tr.league-row-me td,
+.MuiPaper-root.league-view-pane tr.league-row-me td * {
+  color: #ffffff !important;
+}
+.MuiPaper-root.league-view-pane tr.league-row-me:hover td {
+  background-color: #7b1fa2 !important;
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane tr.league-row-me td {
+  background-color: #7b1fa2 !important;
+}
+
+body.win2k-theme .MuiPaper-root.league-view-pane tr.league-row-me td {
+  background-color: #000080 !important;
+}
+body.win2k-theme .MuiPaper-root.league-view-pane tr.league-row-me td,
+body.win2k-theme .MuiPaper-root.league-view-pane tr.league-row-me td * {
+  color: #ffffff !important;
+}
+
+body.teletext-theme .MuiPaper-root.league-view-pane tr.league-row-me td {
+  background-color: #ffff00 !important;
+}
+body.teletext-theme .MuiPaper-root.league-view-pane tr.league-row-me td,
+body.teletext-theme .MuiPaper-root.league-view-pane tr.league-row-me td * {
+  color: #000000 !important;
+}

--- a/frontend/src/components/InvitationLeagueView/styles.css
+++ b/frontend/src/components/InvitationLeagueView/styles.css
@@ -1,0 +1,111 @@
+/* Dark mode - default */
+.MuiPaper-root.league-view-pane {
+  background: linear-gradient(135deg, #23272f 0%, #281455 100%);
+  color: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(106, 27, 154, 0.3);
+  padding: 8px;
+  transition: all 0.3s ease;
+}
+
+/* Light mode */
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane {
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  color: #212121;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.MuiPaper-root.league-view-pane .MuiTypography-h6,
+.MuiPaper-root.league-view-pane .MuiTypography-subtitle2 {
+  color: inherit;
+}
+
+.MuiPaper-root.league-view-pane .MuiDivider-root {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane .MuiDivider-root {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.MuiPaper-root.league-view-pane .MuiButton-root {
+  color: inherit;
+  transition: all 0.3s ease;
+}
+
+.MuiPaper-root.league-view-pane .MuiButton-root:hover {
+  background-color: rgba(171, 71, 188, 0.2);
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane .MuiButton-root:hover {
+  background-color: rgba(106, 27, 154, 0.1);
+}
+
+.MuiPaper-root.league-view-pane .MuiTableCell-root {
+  color: inherit;
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane .MuiTableCell-root {
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+
+.MuiPaper-root.league-view-pane .MuiTableCell-head {
+  background: #2a1a3e;
+  color: inherit;
+  font-weight: 600;
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane .MuiTableCell-head {
+  background: #ede7f6;
+}
+
+.MuiPaper-root.league-view-pane .MuiTableRow-root:hover td {
+  background: rgba(171, 71, 188, 0.12);
+}
+
+html[data-mui-color-scheme='light'] .MuiPaper-root.league-view-pane .MuiTableRow-root:hover td {
+  background: rgba(106, 27, 154, 0.06);
+}
+
+/* Win2k theme */
+body.win2k-theme .MuiPaper-root.league-view-pane {
+  background: #d4d0c8;
+  color: #000000;
+  border-radius: 0;
+  box-shadow: inset -1px -1px 0 #000000, inset 1px 1px 0 #dfdfdf;
+}
+
+body.win2k-theme .MuiPaper-root.league-view-pane .MuiDivider-root {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+body.win2k-theme .MuiPaper-root.league-view-pane .MuiTableCell-head {
+  background: #b8b4ac;
+}
+
+body.win2k-theme .MuiPaper-root.league-view-pane .MuiTableRow-root:hover td {
+  background: rgba(0, 0, 128, 0.08);
+}
+
+/* Teletext theme */
+body.teletext-theme .MuiPaper-root.league-view-pane {
+  background: #000000;
+  color: #ffffff;
+  border-radius: 0;
+  border: 2px solid #ffff00;
+  box-shadow: none;
+  font-family: "Courier New", "Courier", monospace;
+}
+
+body.teletext-theme .MuiPaper-root.league-view-pane .MuiDivider-root {
+  background-color: #ffff00;
+}
+
+body.teletext-theme .MuiPaper-root.league-view-pane .MuiTableCell-head {
+  background: #000080;
+}
+
+body.teletext-theme .MuiPaper-root.league-view-pane .MuiTableRow-root:hover td {
+  background: rgba(255, 255, 0, 0.1);
+}

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -29,7 +29,7 @@ const RightPanel = ({
   const [selectedLeagueId, setSelectedLeagueId] = useState('');
   const [gwMode, setGwMode] = useState(null); // { label, color, isFuture }
 
-  const storageKey = entryId ? `selectedLeagueId_${entryId}` : null;
+  const storageKey = userEntryId ? `selectedLeagueId_${userEntryId}` : null;
 
   useEffect(() => {
     if (!entryId) { setInvLeagues([]); setSelectedLeagueId(''); return; }

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -1,18 +1,20 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Chip from '@mui/material/Chip';
 import { useTheme } from '@mui/material/styles';
-import UserProfilePane from '../UserProfilePane/UserProfilePane';
 import InvitationLeagueView from '../InvitationLeagueView/InvitationLeagueView';
 import FixturesPanel from '../FixturesPanel';
+import axios from '../../api';
 
 const RightPanel = ({ 
-  entryId, 
-  onLeagueClick, 
-  selectedLeague, 
-  onBackFromLeague, 
+  entryId,
   onViewTeam,
   currentGameweek,
   selectedGameweek,
@@ -21,6 +23,36 @@ const RightPanel = ({
 }) => {
   const theme = useTheme();
   const displayGameweek = selectedGameweek || currentGameweek;
+
+  const [invLeagues, setInvLeagues] = useState([]);
+  const [selectedLeagueId, setSelectedLeagueId] = useState('');
+  const [gwMode, setGwMode] = useState(null); // { label, color, isFuture }
+
+  const storageKey = entryId ? `selectedLeagueId_${entryId}` : null;
+
+  useEffect(() => {
+    if (!entryId) { setInvLeagues([]); setSelectedLeagueId(''); return; }
+    axios.get(`/api/entry/${entryId}/profile`)
+      .then(res => {
+        const leagues = (res.data.classicLeagues || []).filter(l => l.league_type !== 's');
+        setInvLeagues(leagues);
+        setSelectedLeagueId(() => {
+          const stored = storageKey ? localStorage.getItem(storageKey) : null;
+          const storedId = stored ? parseInt(stored, 10) : null;
+          if (storedId && leagues.some(l => l.id === storedId)) return storedId;
+          return leagues.length ? leagues[0].id : '';
+        });
+      })
+      .catch(() => { setInvLeagues([]); setSelectedLeagueId(''); });
+  }, [entryId, storageKey]);
+
+  const handleLeagueChange = (id) => {
+    setSelectedLeagueId(id);
+    setGwMode(null); // reset chip until new league data loads
+    if (storageKey) localStorage.setItem(storageKey, String(id));
+  };
+
+  const selectedLeague = invLeagues.find(l => l.id === selectedLeagueId) || null;
 
   return (
     <Box
@@ -34,45 +66,62 @@ const RightPanel = ({
         flexDirection: 'column',
       } }
     >
-      { entryId ? (
-        <Box sx={ { p: 2 } }>
-          <Typography variant='h6' sx={ { mb: 2, fontWeight: 600 } }>
-            League Standings
-          </Typography>
-          { selectedLeague ? (
+      { entryId && invLeagues.length > 0 && (
+        <Box>
+          <Box sx={ { display: 'flex', alignItems: 'center', gap: 1.5, mb: 1, flexWrap: 'wrap', px: 1, pt: 1 } }>
+            <Typography variant='h6' sx={ { fontWeight: 600 } }>
+              League Standings
+            </Typography>
+            { gwMode && (
+              <Chip
+                label={ gwMode.label }
+                color={ gwMode.color }
+                size='small'
+                variant={ gwMode.isFuture ? 'filled' : 'outlined' }
+              />
+            ) }
+            <Box sx={ { flex: 1 } } />
+            { invLeagues.length > 1 && (
+              <FormControl size='small' sx={ { minWidth: 160 } }>
+                <InputLabel>League</InputLabel>
+                <Select
+                  value={ selectedLeagueId }
+                  onChange={ e => handleLeagueChange(e.target.value) }
+                  label='League'
+                >
+                  { invLeagues.map(l => (
+                    <MenuItem key={ l.id } value={ l.id }>{ l.name }</MenuItem>
+                  )) }
+                </Select>
+              </FormControl>
+            ) }
+          </Box>
+          { selectedLeague && (
             <InvitationLeagueView
               league={ selectedLeague }
-              onBack={ onBackFromLeague }
               onViewTeam={ onViewTeam }
-            />
-          ) : (
-            <UserProfilePane
-              entryId={ entryId }
-              onLeagueClick={ onLeagueClick }
+              currentGameweek={ currentGameweek }
+              selectedGameweek={ selectedGameweek }
+              onModeChange={ setGwMode }
             />
           ) }
         </Box>
-      ) : null }
+      ) }
 
       { displayGameweek && (
         <>
-          { entryId && <Divider sx={ { my: 1 } } /> }
+          { entryId && invLeagues.length > 0 && <Divider sx={ { my: 1 } } /> }
           <Box sx={ { p: 2 } }>
             <FixturesPanel gameweek={ displayGameweek } deadline={ gameweekDeadline } liveMatches={ liveMatches } />
           </Box>
         </>
       ) }
-
-
     </Box>
   );
 };
 
 RightPanel.propTypes = {
   entryId: PropTypes.string,
-  onLeagueClick: PropTypes.func,
-  selectedLeague: PropTypes.object,
-  onBackFromLeague: PropTypes.func,
   onViewTeam: PropTypes.func,
   currentGameweek: PropTypes.number,
   selectedGameweek: PropTypes.number,

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -15,6 +15,7 @@ import axios from '../../api';
 
 const RightPanel = ({ 
   entryId,
+  userEntryId,
   onViewTeam,
   currentGameweek,
   selectedGameweek,
@@ -103,6 +104,7 @@ const RightPanel = ({
               currentGameweek={ currentGameweek }
               selectedGameweek={ selectedGameweek }
               onModeChange={ setGwMode }
+              userEntryId={ userEntryId }
             />
           ) }
         </Box>
@@ -122,6 +124,7 @@ const RightPanel = ({
 
 RightPanel.propTypes = {
   entryId: PropTypes.string,
+  userEntryId: PropTypes.string,
   onViewTeam: PropTypes.func,
   currentGameweek: PropTypes.number,
   selectedGameweek: PropTypes.number,

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Chip, Paper, Typography, Divider } from '@mui/material';
+import { Box, Chip, Paper, Typography, Divider, List, ListItem, ListItemText } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import RemoveIcon from '@mui/icons-material/Remove';
 import axios from '../../api';
 import RecommendedTransfers from '../RecommendedTransfers';
 import PlannedTransfers from '../PlannedTransfers';
@@ -192,6 +195,66 @@ const TeamActivityPanel = ({
           </Box>
         </Paper>
       ) }
+
+      { /* My Leagues - between Team Stats and Recent Performance */ }
+      { entryId && profile && (() => {
+        const classicLeagues = profile.classicLeagues || [];
+        const invLeagues = classicLeagues.filter(l => l.league_type !== 's');
+        const genLeagues = classicLeagues.filter(l => l.league_type === 's');
+        const formatNumber = n => (n == null ? 'N/A' : n.toLocaleString());
+        const getRankIcon = (current, last) => {
+          if (last == null || current == null) return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
+          if (last > current) return <ArrowDropUpIcon sx={ { color: theme.palette.success.main, fontSize: 16, verticalAlign: 'middle' } } />;
+          if (last < current) return <ArrowDropDownIcon sx={ { color: theme.palette.error.main, fontSize: 16, verticalAlign: 'middle' } } />;
+          return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
+        };
+
+        return (
+          <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2, flex: '0 0 auto' } }>
+            <Typography variant='h6' sx={ { mb: 1.5, fontWeight: 600 } }>My Leagues</Typography>
+            <Box sx={ { display: 'flex', gap: 2 } }>
+              { genLeagues.length > 0 && (
+                <Box sx={ { flex: 1, minWidth: 0 } }>
+                  <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>General</Typography>
+                  <List dense disablePadding>
+                    { genLeagues.map(l => (
+                      <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
+                        <ListItemText
+                          primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
+                          secondary={
+                            <Typography variant='caption' color='text.secondary'>
+                              Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getRankIcon(l.entry_rank, l.entry_last_rank) }
+                            </Typography>
+                          }
+                        />
+                      </ListItem>
+                    )) }
+                  </List>
+                </Box>
+              ) }
+              { invLeagues.length > 0 && (
+                <Box sx={ { flex: 1, minWidth: 0 } }>
+                  <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>Invitational</Typography>
+                  <List dense disablePadding>
+                    { invLeagues.map(l => (
+                      <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
+                        <ListItemText
+                          primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
+                          secondary={
+                            <Typography variant='caption' color='text.secondary'>
+                              Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getRankIcon(l.entry_rank, l.entry_last_rank) }
+                            </Typography>
+                          }
+                        />
+                      </ListItem>
+                    )) }
+                  </List>
+                </Box>
+              ) }
+            </Box>
+          </Paper>
+        );
+      })() }
 
       { /* Recent Performance - Middle Section */ }
       { entryId && (

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -69,6 +69,17 @@ const TeamActivityPanel = ({
     ? history.reduce((sum, gw) => sum + (gw.points || 0), 0) / history.length
     : 0;
 
+  const classicLeagues = profile ? (profile.classicLeagues || []) : [];
+  const myInvLeagues = classicLeagues.filter(l => l.league_type !== 's');
+  const myGenLeagues = classicLeagues.filter(l => l.league_type === 's');
+
+  const getLeagueRankIcon = (current, last) => {
+    if (last == null || current == null) return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
+    if (last > current) return <ArrowDropUpIcon sx={ { color: theme.palette.success.main, fontSize: 16, verticalAlign: 'middle' } } />;
+    if (last < current) return <ArrowDropDownIcon sx={ { color: theme.palette.error.main, fontSize: 16, verticalAlign: 'middle' } } />;
+    return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
+  };
+
   return (
     <Box
       sx={ {
@@ -197,64 +208,51 @@ const TeamActivityPanel = ({
       ) }
 
       { /* My Leagues - between Team Stats and Recent Performance */ }
-      { entryId && profile && (() => {
-        const classicLeagues = profile.classicLeagues || [];
-        const invLeagues = classicLeagues.filter(l => l.league_type !== 's');
-        const genLeagues = classicLeagues.filter(l => l.league_type === 's');
-        const formatNumber = n => (n == null ? 'N/A' : n.toLocaleString());
-        const getRankIcon = (current, last) => {
-          if (last == null || current == null) return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
-          if (last > current) return <ArrowDropUpIcon sx={ { color: theme.palette.success.main, fontSize: 16, verticalAlign: 'middle' } } />;
-          if (last < current) return <ArrowDropDownIcon sx={ { color: theme.palette.error.main, fontSize: 16, verticalAlign: 'middle' } } />;
-          return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 16, verticalAlign: 'middle' } } />;
-        };
-
-        return (
-          <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2, flex: '0 0 auto' } }>
-            <Typography variant='h6' sx={ { mb: 1.5, fontWeight: 600 } }>My Leagues</Typography>
-            <Box sx={ { display: 'flex', gap: 2 } }>
-              { genLeagues.length > 0 && (
-                <Box sx={ { flex: 1, minWidth: 0 } }>
-                  <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>General</Typography>
-                  <List dense disablePadding>
-                    { genLeagues.map(l => (
-                      <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
-                        <ListItemText
-                          primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
-                          secondary={
-                            <Typography variant='caption' color='text.secondary'>
-                              Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getRankIcon(l.entry_rank, l.entry_last_rank) }
-                            </Typography>
-                          }
-                        />
-                      </ListItem>
-                    )) }
-                  </List>
-                </Box>
-              ) }
-              { invLeagues.length > 0 && (
-                <Box sx={ { flex: 1, minWidth: 0 } }>
-                  <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>Invitational</Typography>
-                  <List dense disablePadding>
-                    { invLeagues.map(l => (
-                      <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
-                        <ListItemText
-                          primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
-                          secondary={
-                            <Typography variant='caption' color='text.secondary'>
-                              Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getRankIcon(l.entry_rank, l.entry_last_rank) }
-                            </Typography>
-                          }
-                        />
-                      </ListItem>
-                    )) }
-                  </List>
-                </Box>
-              ) }
-            </Box>
-          </Paper>
-        );
-      })() }
+      { entryId && profile && (myInvLeagues.length > 0 || myGenLeagues.length > 0) && (
+        <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2, flex: '0 0 auto' } }>
+          <Typography variant='h6' sx={ { mb: 1.5, fontWeight: 600 } }>My Leagues</Typography>
+          <Box sx={ { display: 'flex', gap: 2 } }>
+            { myGenLeagues.length > 0 && (
+              <Box sx={ { flex: 1, minWidth: 0 } }>
+                <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>General</Typography>
+                <List dense disablePadding>
+                  { myGenLeagues.map(l => (
+                    <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
+                      <ListItemText
+                        primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
+                        secondary={
+                          <Typography variant='caption' color='text.secondary'>
+                            Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getLeagueRankIcon(l.entry_rank, l.entry_last_rank) }
+                          </Typography>
+                        }
+                      />
+                    </ListItem>
+                  )) }
+                </List>
+              </Box>
+            ) }
+            { myInvLeagues.length > 0 && (
+              <Box sx={ { flex: 1, minWidth: 0 } }>
+                <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>Invitational</Typography>
+                <List dense disablePadding>
+                  { myInvLeagues.map(l => (
+                    <ListItem key={ l.id } disablePadding sx={ { py: 0.25 } }>
+                      <ListItemText
+                        primary={ <Typography variant='body2' noWrap>{ l.name }</Typography> }
+                        secondary={
+                          <Typography variant='caption' color='text.secondary'>
+                            Rank: { formatNumber(l.entry_rank) }{ ' ' }{ getLeagueRankIcon(l.entry_rank, l.entry_last_rank) }
+                          </Typography>
+                        }
+                      />
+                    </ListItem>
+                  )) }
+                </List>
+              </Box>
+            ) }
+          </Box>
+        </Paper>
+      ) }
 
       { /* Recent Performance - Middle Section */ }
       { entryId && (

--- a/frontend/src/components/UserProfilePane/UserProfilePane.jsx
+++ b/frontend/src/components/UserProfilePane/UserProfilePane.jsx
@@ -8,11 +8,11 @@ import RemoveIcon from '@mui/icons-material/Remove';
 import axios from '../../api';
 import './styles.css';
 
-const getRankChangeIcon = (current, last) => {
-  if (last == null || current == null) return <RemoveIcon sx={ { color: 'grey.500', fontSize: 18, verticalAlign: 'middle' } } />;
-  if (last > current) return <ArrowDropUpIcon sx={ { color: 'green', fontSize: 18, verticalAlign: 'middle' } } />;
-  if (last < current) return <ArrowDropDownIcon sx={ { color: 'red', fontSize: 18, verticalAlign: 'middle' } } />;
-  return <RemoveIcon sx={ { color: 'grey.500', fontSize: 18, verticalAlign: 'middle' } } />;
+const getRankChangeIcon = (current, last, theme) => {
+  if (last == null || current == null) return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 18, verticalAlign: 'middle' } } />;
+  if (last > current) return <ArrowDropUpIcon sx={ { color: theme?.palette?.success?.main ?? 'green', fontSize: 18, verticalAlign: 'middle' } } />;
+  if (last < current) return <ArrowDropDownIcon sx={ { color: theme?.palette?.error?.main ?? 'red', fontSize: 18, verticalAlign: 'middle' } } />;
+  return <RemoveIcon sx={ { color: 'text.secondary', fontSize: 18, verticalAlign: 'middle' } } />;
 };
 
 const UserProfilePane = ({ entryId, onLeagueClick }) => {
@@ -67,7 +67,7 @@ const UserProfilePane = ({ entryId, onLeagueClick }) => {
                   secondary={
                     <>
                       Rank: { formatNumber(l.entry_rank) }{ ' ' }
-                      { getRankChangeIcon(l.entry_rank, l.entry_last_rank) }
+                      { getRankChangeIcon(l.entry_rank, l.entry_last_rank, theme) }
                     </>
                   }
                 />
@@ -86,22 +86,24 @@ const UserProfilePane = ({ entryId, onLeagueClick }) => {
               </ListItem>
             ) }
             { invitationalLeagues.map(l => (
-              <ListItem key={ l.id } disablePadding>
+              <ListItem key={ l.id } disablePadding sx={ { mb: 0.5 } }>
                 <ListItemText
                   primary={
                     <Button
                       size='small'
-                      variant='text'
+                      variant='outlined'
                       onClick={ () => onLeagueClick && onLeagueClick(l) }
                       sx={ {
-                        p: 0,
-                        minWidth: 0,
                         textTransform: 'none',
-                        fontWeight: 'normal',
+                        fontWeight: 500,
                         textAlign: 'left',
                         justifyContent: 'flex-start',
-                        color: 'inherit',
-                        '&:hover': { textDecoration: 'underline', background: 'none' },
+                        width: '100%',
+                        borderColor: 'primary.main',
+                        color: 'primary.main',
+                        py: 0.25,
+                        px: 1,
+                        '&:hover': { borderColor: 'secondary.main', color: 'secondary.main', backgroundColor: 'rgba(171,71,188,0.08)' },
                       } }
                     >
                       { l.name }
@@ -110,7 +112,7 @@ const UserProfilePane = ({ entryId, onLeagueClick }) => {
                   secondary={
                     <>
                       Rank: { formatNumber(l.entry_rank) }{ ' ' }
-                      { getRankChangeIcon(l.entry_rank, l.entry_last_rank) }
+                      { getRankChangeIcon(l.entry_rank, l.entry_last_rank, theme) }
                     </>
                   }
                 />


### PR DESCRIPTION
This pull request significantly improves the Invitation League Standings experience by introducing live and predicted points, dynamic gameweek modes, and a modernized UI. The backend now provides live and predicted points for each team, while the frontend offers a more interactive and visually appealing league standings panel, including theme-aware styling and a gameweek mode chip.

**Backend enhancements for live/predicted points:**

- The league standings endpoint (`getLeagueStandings` in `fplController.js`) now fetches live gameweek data and computes both live and predicted points for each entry. The response includes whether the current gameweek is active, enabling the frontend to display the appropriate mode. [[1]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR1133-R1194) [[2]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR1204)

**Frontend Invitation League Standings improvements:**

- The `InvitationLeagueView` component now dynamically determines and displays the mode (Live, Predicted, or Past GW), shows live/predicted points as appropriate, and uses theme-based color for rank change icons. The table layout and controls are simplified, and the component notifies its parent of the current display mode. [[1]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL22-R80) [[2]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL117-R144) [[3]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL162-R161)
- The `RightPanel` now manages league selection, persists the selected league per user, and displays a chip indicating the current standings mode. It loads the user's leagues on demand and switches between them via a dropdown. [[1]](diffhunk://#diff-141a1192db60f4b7255efb2fbc666e0676828408130fcb93b559c75844903a8bL1-L15) [[2]](diffhunk://#diff-141a1192db60f4b7255efb2fbc666e0676828408130fcb93b559c75844903a8bR27-R56) [[3]](diffhunk://#diff-141a1192db60f4b7255efb2fbc666e0676828408130fcb93b559c75844903a8bL37-L75)

**UI and styling updates:**

- Added a new stylesheet for `InvitationLeagueView` with theme-aware backgrounds, table, and button styling, supporting dark, light, Win2k, and Teletext themes.

**Code cleanup and refactoring:**

- Removed unused props and legacy league drill-down logic from `App.jsx` and related components, simplifying state management. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L48) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L736-R735) [[3]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL12-L13)

**Bug fixes:**

- Fixed a logic error in `getUserTeamForEntry` that could have prevented correct enrichment of player stats for active gameweeks.