### PR TITLE
Implement tabbed management sections and enhance TeamActivityPanel

### DIFF
--- a/backend/entities/Player.js
+++ b/backend/entities/Player.js
@@ -57,14 +57,14 @@ class Player {
     // useActualPoints = false → future/current GW  → use ep_next (prediction)
     const useActualPoints  = enrichment.useActualPoints ?? false;
     const gwStats = raw.gameweek_stats ?? null;
-    // When official bonus hasn't been assigned yet but we have a BPS estimate,
-    // add it to the live total so the card reflects the provisional total.
-    // For DGWs: gwStats.provisional_bonus only covers unsettled fixtures, so
-    // we add it regardless of the settled aggregate bonus (gwStats.bonus).
+    // The FPL live endpoint's total_points already includes whatever bonus
+    // FPL has provisionally assigned (gwStats.bonus). Our BPS estimate
+    // (provisional_bonus) may duplicate that value, so we only add the
+    // portion that exceeds what FPL has already reflected in event_points.
     const unassignedProvisionalBonus =
       useActualPoints &&
       gwStats?.provisional_bonus != null
-        ? gwStats.provisional_bonus
+        ? Math.max(0, gwStats.provisional_bonus - (gwStats.bonus ?? 0))
         : 0;
     const rawBase          = useActualPoints
       ? (raw.event_points ?? 0) + unassignedProvisionalBonus

--- a/backend/models/dataProvider.js
+++ b/backend/models/dataProvider.js
@@ -8,6 +8,21 @@ const { validateEntryId, validateGameweek, validatePlayerId, validateLeagueId } 
 // Keys are URL strings; values are { data, expiresAt }.
 // ---------------------------------------------------------------------------
 const cache = new Map();
+const MAX_CACHE_SIZE = 1000;
+
+const pruneExpiredEntries = (now = Date.now()) => {
+  for (const [key, value] of cache.entries()) {
+    if (value.expiresAt <= now) cache.delete(key);
+  }
+};
+
+const enforceCacheSize = () => {
+  while (cache.size > MAX_CACHE_SIZE) {
+    const oldestKey = cache.keys().next().value;
+    if (!oldestKey) break;
+    cache.delete(oldestKey);
+  }
+};
 
 /**
  * Fetch a URL with caching.  `ttlMs` is the time-to-live in milliseconds.
@@ -15,10 +30,20 @@ const cache = new Map();
 const cachedGet = async (url, ttlMs) => {
   const now = Date.now();
   const hit = cache.get(url);
-  if (hit && now < hit.expiresAt) return hit.data;
+  if (hit) {
+    if (now < hit.expiresAt) {
+      cache.delete(url);
+      cache.set(url, hit);
+      return hit.data;
+    }
+    cache.delete(url);
+  }
+
+  pruneExpiredEntries(now);
 
   const response = await axios.get(url);
-  cache.set(url, { data: response.data, expiresAt: now + ttlMs });
+  cache.set(url, { data: response.data, expiresAt: Date.now() + ttlMs });
+  enforceCacheSize();
   return response.data;
 };
 

--- a/backend/models/dataProvider.js
+++ b/backend/models/dataProvider.js
@@ -3,6 +3,34 @@ const fs = require('fs').promises;
 const path = require('path');
 const { validateEntryId, validateGameweek, validatePlayerId, validateLeagueId } = require('../utils/validation');
 
+// ---------------------------------------------------------------------------
+// Simple in-memory TTL cache to reduce repeated FPL API requests.
+// Keys are URL strings; values are { data, expiresAt }.
+// ---------------------------------------------------------------------------
+const cache = new Map();
+
+/**
+ * Fetch a URL with caching.  `ttlMs` is the time-to-live in milliseconds.
+ */
+const cachedGet = async (url, ttlMs) => {
+  const now = Date.now();
+  const hit = cache.get(url);
+  if (hit && now < hit.expiresAt) return hit.data;
+
+  const response = await axios.get(url);
+  cache.set(url, { data: response.data, expiresAt: now + ttlMs });
+  return response.data;
+};
+
+// TTL constants
+const TTL_BOOTSTRAP  = 5 * 60 * 1000;  // 5 min  – rarely changes
+const TTL_PROFILE    = 2 * 60 * 1000;  // 2 min  – entry/history/leagues
+const TTL_PICKS      = 60 * 1000;      // 1 min  – picks can change during active GW
+const TTL_LIVE       = 30 * 1000;      // 30 sec – live scores change often
+const TTL_FIXTURES   = 5 * 60 * 1000;  // 5 min
+const TTL_LEAGUE     = 2 * 60 * 1000;  // 2 min
+const TTL_TRANSFERS  = 2 * 60 * 1000;  // 2 min
+
 // Environment flag to control data source
 // USE_FPL_API: 'true' (default) - Use real FPL API
 // USE_FPL_API: 'false' - Use local mock data for testing
@@ -37,8 +65,7 @@ const loadMockData = async (filename) => {
 const fetchBootstrapStatic = async () => {
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/bootstrap-static/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_BOOTSTRAP);
   } else {
     console.log('[Mock Mode] Fetching bootstrap-static from local data');
     return await loadMockData('bootstrap-static.json');
@@ -58,8 +85,7 @@ const fetchPlayerPicks = async (entryId, eventId) => {
   
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/entry/${validatedEntryId}/event/${validatedEventId}/picks/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_PICKS);
   } else {
     console.log(`[Mock Mode] Fetching player picks for entry ${validatedEntryId} event ${validatedEventId} from local data`);
     return await loadMockData('player-picks.json');
@@ -77,8 +103,7 @@ const fetchElementSummary = async (playerId) => {
   
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/element-summary/${validatedPlayerId}/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_PROFILE);
   } else {
     console.log(`[Mock Mode] Fetching element summary for player ${validatedPlayerId} from local data`);
     return await loadMockData('element-summary.json');
@@ -92,8 +117,7 @@ const fetchElementSummary = async (playerId) => {
 const fetchFixtures = async () => {
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/fixtures/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_FIXTURES);
   } else {
     console.log('[Mock Mode] Fetching fixtures from local data');
     return await loadMockData('fixtures.json');
@@ -109,8 +133,7 @@ const fetchEventFixtures = async (eventId) => {
   const validatedEventId = validateGameweek(eventId);
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/fixtures/?event=${validatedEventId}`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_FIXTURES);
   } else {
     console.log(`[Mock Mode] Fetching event ${validatedEventId} fixtures from local data`);
     const allFixtures = await loadMockData('fixtures.json');
@@ -129,8 +152,7 @@ const fetchLiveGameweek = async (eventId) => {
   
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/event/${validatedEventId}/live/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_LIVE);
   } else {
     console.log(`[Mock Mode] Fetching live gameweek ${validatedEventId} from local data`);
     return await loadMockData('live-gameweek.json');
@@ -148,8 +170,7 @@ const fetchEntry = async (entryId) => {
   
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/entry/${validatedEntryId}/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_PROFILE);
   } else {
     console.log(`[Mock Mode] Fetching entry ${validatedEntryId} from local data`);
     return await loadMockData('entry.json');
@@ -167,8 +188,7 @@ const fetchHistory = async (entryId) => {
   
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/entry/${validatedEntryId}/history/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_PROFILE);
   } else {
     console.log(`[Mock Mode] Fetching history for entry ${validatedEntryId} from local data`);
     return await loadMockData('history.json');
@@ -184,8 +204,7 @@ const fetchEntryTransfers = async (entryId) => {
   const validatedEntryId = validateEntryId(entryId);
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/entry/${validatedEntryId}/transfers/`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_TRANSFERS);
   } else {
     console.log(`[Mock Mode] Fetching transfers for entry ${validatedEntryId} from local data`);
     return [];
@@ -204,8 +223,7 @@ const fetchLeagueStandings = async (leagueId, page = 1) => {
 
   if (USE_FPL_API) {
     const url = `${FPL_API_BASE}/leagues-classic/${validatedLeagueId}/standings/?page_standings=${page}`;
-    const response = await axios.get(url);
-    return response.data;
+    return await cachedGet(url, TTL_LEAGUE);
   } else {
     console.log(`[Mock Mode] Fetching league standings for league ${validatedLeagueId} from local data`);
     return await loadMockData('league-standings.json');

--- a/backend/models/fplModel.js
+++ b/backend/models/fplModel.js
@@ -169,16 +169,22 @@ const enrichPlayersWithGameweekStats = async (players, targetEventId) => {
     // pipeline run assigns it, so we estimate for any started fixture where
     // bonus hasn't been assigned yet (finished_provisional covers the window
     // between the final whistle and the official freeze).
+    //
+    // We store { total, byFixture: { [fixtureId]: bonus } } per element so that
+    // DGW per-fixture breakdowns can show the correct fixture's bonus rather
+    // than duplicating the aggregate across every fixture with bonus===0.
     const provisionalBonusMap = {};
     for (const fixture of eventFixtures) {
       const bonusNotSettled = fixture.started && fixture.stats?.length &&
         !fixture.stats.find(s => s.identifier === 'bonus' && (s.h.length > 0 || s.a.length > 0));
       if (bonusNotSettled) {
         const bonuses = estimateBonusFromBPS(fixture.stats);
-        // Accumulate (sum) bonus per element to correctly handle DGWs where a
-        // player may appear in more than one in-progress fixture.
         for (const [elementId, bonus] of Object.entries(bonuses)) {
-          provisionalBonusMap[elementId] = (provisionalBonusMap[elementId] ?? 0) + bonus;
+          if (!provisionalBonusMap[elementId]) {
+            provisionalBonusMap[elementId] = { total: 0, byFixture: {} };
+          }
+          provisionalBonusMap[elementId].total += bonus;
+          provisionalBonusMap[elementId].byFixture[fixture.id] = bonus;
         }
       }
     }
@@ -203,7 +209,10 @@ const enrichPlayersWithGameweekStats = async (players, targetEventId) => {
         bonus: element.stats.bonus,
         bps: element.stats.bps,
         provisional_bonus: element.id in provisionalBonusMap
-          ? provisionalBonusMap[element.id]
+          ? provisionalBonusMap[element.id].total
+          : null,
+        provisional_bonus_by_fixture: element.id in provisionalBonusMap
+          ? provisionalBonusMap[element.id].byFixture
           : null,
         explain: element.explain ?? [],
       };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ import useLiveScores from './hooks/useLiveScores';
 import RightPanel from './components/RightPanel';
 import RecommendedTransfers from './components/RecommendedTransfers';
 import TeamActivityPanel from './components/TeamActivityPanel';
+import PlannedTransfers from './components/PlannedTransfers';
+import SectionBar from './components/SectionBar';
 
 const TEAM_VIEW = {
   USER: 'user',
@@ -52,6 +54,9 @@ const App = () => {
   // Planned chips across all future GWs: { [gw]: chipId }.  Loaded from storage
   // on mount and kept in sync whenever a chip is toggled.
   const [plannedChipsByGW, setPlannedChipsByGW] = useState({});
+  const [activeSection, setActiveSection] = useState('overview');
+  const userOverriddenSection = useRef(false);
+  const prevGameweekRef = useRef(null);
 
   const handleChipToggle = (chipId) => {
     const next = activeChip === chipId ? null : chipId;
@@ -208,6 +213,56 @@ const App = () => {
     // Prefer a planned per-gameweek chip (persisted to storage), fallback to transient `activeChip`.
     return plannedChipsByGW[viewedGW] ?? activeChip ?? null;
   }, [gameweekInfo, isHighestPredictedTeam, viewingOpponentId, plannedChipsByGW, activeChip]);
+
+  // Reset section when switching between user and highest team
+  const prevIsHighestRef = useRef(isHighestPredictedTeam);
+  useEffect(() => {
+    if (prevIsHighestRef.current !== isHighestPredictedTeam) {
+      prevIsHighestRef.current = isHighestPredictedTeam;
+      setActiveSection('active');
+      setSelectedGameweek(null);
+      userOverriddenSection.current = false;
+    }
+  }, [isHighestPredictedTeam]);
+
+  // Track whether the CURRENT (not selected) gameweek is still active.
+  // This is kept independently so the Active tab dot doesn't flicker off
+  // when the user switches to Planning (which loads a future GW response).
+  const [currentGwIsActive, setCurrentGwIsActive] = useState(false);
+  useEffect(() => {
+    // Only update when viewing the actual current GW (selectedGameweek is null
+    // or matches currentGameweek) so future-GW responses don't overwrite it.
+    if (!selectedGameweek || selectedGameweek === currentGameweek) {
+      setCurrentGwIsActive(!!isLive);
+    }
+  }, [isLive, selectedGameweek, currentGameweek]);
+
+  // Auto-switch to Active section when a gameweek goes live, unless the user
+  // has manually selected a section. Reset the override flag on GW change.
+  useEffect(() => {
+    if (isLive && !userOverriddenSection.current) {
+      setActiveSection('active');
+    }
+  }, [isLive]);
+
+  useEffect(() => {
+    if (currentGameweek && currentGameweek !== prevGameweekRef.current) {
+      prevGameweekRef.current = currentGameweek;
+      userOverriddenSection.current = false;
+    }
+  }, [currentGameweek]);
+
+  const handleSectionChange = (section) => {
+    setActiveSection(section);
+    userOverriddenSection.current = true;
+    if (section === 'active') {
+      setSelectedGameweek(null);
+    } else if (section === 'planning' || section === 'next') {
+      setSelectedGameweek(currentGameweek ? currentGameweek + 1 : null);
+    } else {
+      setSelectedGameweek(null);
+    }
+  };
 
   useEffect(() => {
     if (snackbar.message) setSnackbarOpen(true);
@@ -541,6 +596,13 @@ const App = () => {
         benchPoints={ displayBenchPoints }
         isPast={ gameweekInfo?.isPast }
         isActive={ gameweekInfo?.isActive }
+        gameweekLocked={ activeSection === 'active' || activeSection === 'next' }
+      />
+      <SectionBar
+        activeSection={ activeSection }
+        onSectionChange={ handleSectionChange }
+        isLive={ currentGwIsActive }
+        isHighestPredictedTeam={ isHighestPredictedTeam }
       />
       <Container maxWidth={ false } sx={ { flex: 1, marginTop: '8px', display: 'flex', flexDirection: 'column', px: { xs: 1, sm: 2 } } }>
         <Box sx={ { display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2, flex: 1, alignItems: 'flex-start' } }>
@@ -696,7 +758,7 @@ const App = () => {
                 </Box>
               </Box>
               <Box sx={ { mt: 1, borderRadius: 2, overflow: 'hidden', bgcolor: 'background.paper' } }>
-                <LiveBanner isLive={ isLive } lastUpdated={ lastUpdated } />
+                { activeSection === 'active' && <LiveBanner isLive={ isLive } lastUpdated={ lastUpdated } /> }
                 { pitchView === 'formation' ? (
                   <TeamFormation
                     activePlayers={ effectiveActivePlayers }
@@ -739,17 +801,48 @@ const App = () => {
           
           { /* Middle - Panel */ }
           <Box sx={ { flex: { xs: '1 1 auto', lg: '0 0 28%' }, width: { xs: '100%', lg: 'auto' }, display: 'flex', flexDirection: 'column', minHeight: { xs: 'auto', lg: '600px' } } }>
-            <RightPanel
-              entryId={ viewingOpponentId || currentEntryId }
-              onViewTeam={ handleViewOpponentTeam }
-              currentGameweek={ currentGameweek }
-              selectedGameweek={ selectedGameweek }
-              viewingOpponentId={ viewingOpponentId }
-              currentEntryId={ currentEntryId }
-              userEntryId={ userEntryId }
-              gameweekDeadline={ gameweekInfo?.data?.deadline_time }
-              liveMatches={ liveMatches }
-            />
+            { activeSection === 'planning' ? (
+              <Box sx={ { display: 'flex', flexDirection: 'column', gap: 2 } }>
+                { currentEntryId && !viewingOpponentId && currentGameweek && (
+                  <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2 } }>
+                    <PlannedTransfers
+                      plannedTransfers={ plannedTransfers }
+                      onRemove={ removePlannedTransfer }
+                      onUpdateGameweek={ updateTransferGameweek }
+                      onAdd={ addPlannedTransfer }
+                      team={ [...activePlayers, ...reservePlayers] }
+                      allPlayers={ allPlayers }
+                      currentGameweek={ currentGameweek }
+                      compact={ false }
+                      voidedTransferIds={ voidedTransferIds }
+                      freeHitGWs={ freeHitGWs }
+                    />
+                  </Paper>
+                ) }
+                { currentEntryId && !viewingOpponentId && currentGameweek && (
+                  <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2 } }>
+                    <RecommendedTransfers
+                      entryId={ currentEntryId }
+                      currentGameweek={ currentGameweek }
+                      compact={ false }
+                    />
+                  </Paper>
+                ) }
+              </Box>
+            ) : (
+              <RightPanel
+                entryId={ viewingOpponentId || currentEntryId }
+                onViewTeam={ handleViewOpponentTeam }
+                currentGameweek={ currentGameweek }
+                selectedGameweek={ selectedGameweek }
+                viewingOpponentId={ viewingOpponentId }
+                currentEntryId={ currentEntryId }
+                userEntryId={ userEntryId }
+                gameweekDeadline={ gameweekInfo?.data?.deadline_time }
+                liveMatches={ liveMatches }
+                activeSection={ activeSection }
+              />
+            ) }
           </Box>
 
           { /* Right - Activity & Stats */ }
@@ -767,6 +860,7 @@ const App = () => {
               allPlayers={ allPlayers }
               voidedTransferIds={ voidedTransferIds }
               freeHitGWs={ freeHitGWs }
+              activeSection={ activeSection }
             />
           </Box>
         </Box>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -800,9 +800,9 @@ const App = () => {
           </Box>
           
           { /* Middle - Panel */ }
-          <Box sx={ { flex: { xs: '1 1 auto', lg: '0 0 28%' }, width: { xs: '100%', lg: 'auto' }, display: 'flex', flexDirection: 'column', minHeight: { xs: 'auto', lg: '600px' } } }>
+          <Box sx={ { flex: { xs: '1 1 auto', lg: '0 0 28%' }, width: { xs: '100%', lg: 'auto' }, minWidth: 0, display: 'flex', flexDirection: 'column', minHeight: { xs: 'auto', lg: '600px' } } }>
             { activeSection === 'planning' ? (
-              <Box sx={ { display: 'flex', flexDirection: 'column', gap: 2 } }>
+              <Box sx={ { display: 'flex', flexDirection: 'column', gap: 2, width: '100%' } }>
                 { currentEntryId && !viewingOpponentId && currentGameweek && (
                   <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2 } }>
                     <PlannedTransfers

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,8 @@ import { useTheme } from '@mui/material/styles';
 import TableRowsIcon from '@mui/icons-material/TableRows';
 import GridViewIcon from '@mui/icons-material/GridView';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import Tooltip from '@mui/material/Tooltip';
 import TeamFormation from './components/TeamFormation/TeamFormation';
 import TeamListView from './components/TeamListView/TeamListView';
@@ -701,9 +703,16 @@ const App = () => {
                     ) }
                   </Box>
                   { /* Row 2 — values / toggle */ }
-                  <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>
-                    { displayTotalPoints }
-                  </Typography>
+                  <Box sx={ { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25 } }>
+                    <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>
+                      { displayTotalPoints }
+                    </Typography>
+                    { gameweekInfo?.isActive && gameweekInfo?.data?.average_entry_score != null && (
+                      displayTotalPoints >= gameweekInfo.data.average_entry_score
+                        ? <ArrowUpwardIcon sx={ { fontSize: 16, color: 'success.main' } } />
+                        : <ArrowDownwardIcon sx={ { fontSize: 16, color: 'error.main' } } />
+                    ) }
+                  </Box>
                   <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>
                     { displayBenchPoints }
                   </Typography>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -56,7 +56,9 @@ const App = () => {
   // Planned chips across all future GWs: { [gw]: chipId }.  Loaded from storage
   // on mount and kept in sync whenever a chip is toggled.
   const [plannedChipsByGW, setPlannedChipsByGW] = useState({});
-  const [activeSection, setActiveSection] = useState('overview');
+  const [activeSection, setActiveSection] = useState(() => (
+    teamView === TEAM_VIEW.HIGHEST ? 'active' : 'overview'
+  ));
   const userOverriddenSection = useRef(false);
   const prevGameweekRef = useRef(null);
 
@@ -227,6 +229,16 @@ const App = () => {
     }
   }, [isHighestPredictedTeam]);
 
+  useEffect(() => {
+    const allowedSections = isHighestPredictedTeam
+      ? ['active', 'next']
+      : ['active', 'planning', 'overview'];
+    if (!allowedSections.includes(activeSection)) {
+      setActiveSection(allowedSections[0]);
+      userOverriddenSection.current = false;
+    }
+  }, [activeSection, isHighestPredictedTeam]);
+
   // Track whether the CURRENT (not selected) gameweek is still active.
   // This is kept independently so the Active tab dot doesn't flicker off
   // when the user switches to Planning (which loads a future GW response).
@@ -260,7 +272,7 @@ const App = () => {
     if (section === 'active') {
       setSelectedGameweek(null);
     } else if (section === 'planning' || section === 'next') {
-      setSelectedGameweek(currentGameweek ? currentGameweek + 1 : null);
+      setSelectedGameweek(currentGameweek != null && currentGameweek < 38 ? currentGameweek + 1 : null);
     } else {
       setSelectedGameweek(null);
     }
@@ -849,7 +861,6 @@ const App = () => {
                 userEntryId={ userEntryId }
                 gameweekDeadline={ gameweekInfo?.data?.deadline_time }
                 liveMatches={ liveMatches }
-                activeSection={ activeSection }
               />
             ) }
           </Box>
@@ -859,16 +870,7 @@ const App = () => {
             <TeamActivityPanel
               entryId={ viewingOpponentId || currentEntryId }
               currentGameweek={ currentGameweek }
-              currentEntryId={ currentEntryId }
               viewingOpponentId={ viewingOpponentId }
-              plannedTransfers={ plannedTransfers }
-              onRemovePlannedTransfer={ removePlannedTransfer }
-              onUpdatePlannedTransferGameweek={ updateTransferGameweek }
-              onAddPlannedTransfer={ addPlannedTransfer }
-              team={ [...activePlayers, ...reservePlayers] }
-              allPlayers={ allPlayers }
-              voidedTransferIds={ voidedTransferIds }
-              freeHitGWs={ freeHitGWs }
               activeSection={ activeSection }
               isCurrentGwActive={ currentGwIsActive }
             />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -861,6 +861,7 @@ const App = () => {
               voidedTransferIds={ voidedTransferIds }
               freeHitGWs={ freeHitGWs }
               activeSection={ activeSection }
+              isCurrentGwActive={ currentGwIsActive }
             />
           </Box>
         </Box>

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -39,6 +39,7 @@ const NavigationBar = ({
   selectedGameweek,
   setSelectedGameweek,
   currentGameweek,
+  gameweekLocked,
 }) => {
   const { mode, toggleTheme, toggleWin2k, toggleTeletext } = useThemeMode();
   const [teamIdDialogOpen, setTeamIdDialogOpen] = React.useState(false);
@@ -164,12 +165,12 @@ const NavigationBar = ({
 
             { /* Gameweek Selector */ }
             <Box sx={ { display: 'flex', alignItems: 'center', gap: 0.25 } }>
-              <Tooltip title='Previous gameweek'>
+              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active view' : 'Previous gameweek' }>
                 <span>
                   <IconButton
                     size='small'
                     color='inherit'
-                    disabled={ (selectedGameweek || currentGameweek || 1) <= 1 }
+                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) <= 1 }
                     onClick={ () => {
                       const current = selectedGameweek || currentGameweek || 1;
                       setSelectedGameweek(current - 1 === currentGameweek ? null : current - 1);
@@ -186,6 +187,7 @@ const NavigationBar = ({
                   inputProps={ { 'aria-label': 'Gameweek' } }
                   value={ selectedGameweek || currentGameweek || '' }
                   label='GW'
+                  disabled={ gameweekLocked }
                   onChange={ (e) => setSelectedGameweek(e.target.value === currentGameweek ? null : e.target.value) }
                   sx={ { 
                     bgcolor: 'background.paper',
@@ -199,12 +201,12 @@ const NavigationBar = ({
                   )) }
                 </Select>
               </FormControl>
-              <Tooltip title='Next gameweek'>
+              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active view' : 'Next gameweek' }>
                 <span>
                   <IconButton
                     size='small'
                     color='inherit'
-                    disabled={ (selectedGameweek || currentGameweek || 1) >= 38 }
+                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) >= 38 }
                     onClick={ () => {
                       const current = selectedGameweek || currentGameweek || 1;
                       setSelectedGameweek(current + 1 === currentGameweek ? null : current + 1);

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -165,7 +165,7 @@ const NavigationBar = ({
 
             { /* Gameweek Selector */ }
             <Box sx={ { display: 'flex', alignItems: 'center', gap: 0.25 } }>
-              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active view' : 'Previous gameweek' }>
+              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active/Next view' : 'Previous gameweek' }>
                 <span>
                   <IconButton
                     size='small'
@@ -201,7 +201,7 @@ const NavigationBar = ({
                   )) }
                 </Select>
               </FormControl>
-              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active view' : 'Next gameweek' }>
+              <Tooltip title={ gameweekLocked ? 'Gameweek locked in Active/Next view' : 'Next gameweek' }>
                 <span>
                   <IconButton
                     size='small'
@@ -277,6 +277,7 @@ NavigationBar.propTypes = {
   selectedGameweek: PropTypes.number,
   setSelectedGameweek: PropTypes.func,
   currentGameweek: PropTypes.number,
+  gameweekLocked: PropTypes.bool,
 };
 
 export default NavigationBar;

--- a/frontend/src/components/PlayerStatsDialog/PlayerStatsDialog.jsx
+++ b/frontend/src/components/PlayerStatsDialog/PlayerStatsDialog.jsx
@@ -326,9 +326,12 @@ const PlayerStatsDialog = ({ open, onClose, player, viewedGameweek, liveMatches 
                 const label = matchingOpp
                   ? `vs ${matchingOpp.opponent_short} (${matchingOpp.is_home ? 'H' : 'A'})`
                   : `Fixture ${i + 1}`;
-                // If official bonus not yet settled, use provisional BPS estimate
+                // If official bonus not yet settled, use the per-fixture provisional
+                // BPS estimate (not the aggregate total) to avoid showing the same
+                // bonus on every fixture that has bonus===0 in a DGW.
+                const byFixture = gameweekStats?.provisional_bonus_by_fixture;
                 const provisionalBonusValue = entry.bonus === 0
-                    ? (gameweekStats?.provisional_bonus ?? null)
+                    ? (byFixture ? (byFixture[entry.fixture] ?? null) : (gameweekStats?.provisional_bonus ?? null))
                     : null;
                 return (
                   <Box key={ entry.fixture ?? i } sx={ { mb: 2 } }>

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -21,7 +21,6 @@ const RightPanel = ({
   selectedGameweek,
   gameweekDeadline,
   liveMatches,
-  activeSection,
 }) => {
   const theme = useTheme();
   const displayGameweek = selectedGameweek || currentGameweek;
@@ -131,7 +130,6 @@ RightPanel.propTypes = {
   selectedGameweek: PropTypes.number,
   gameweekDeadline: PropTypes.string,
   liveMatches: PropTypes.array,
-  activeSection: PropTypes.string,
 };
 
 export default RightPanel;

--- a/frontend/src/components/RightPanel/RightPanel.jsx
+++ b/frontend/src/components/RightPanel/RightPanel.jsx
@@ -21,6 +21,7 @@ const RightPanel = ({
   selectedGameweek,
   gameweekDeadline,
   liveMatches,
+  activeSection,
 }) => {
   const theme = useTheme();
   const displayGameweek = selectedGameweek || currentGameweek;
@@ -130,6 +131,7 @@ RightPanel.propTypes = {
   selectedGameweek: PropTypes.number,
   gameweekDeadline: PropTypes.string,
   liveMatches: PropTypes.array,
+  activeSection: PropTypes.string,
 };
 
 export default RightPanel;

--- a/frontend/src/components/SectionBar/SectionBar.jsx
+++ b/frontend/src/components/SectionBar/SectionBar.jsx
@@ -16,7 +16,11 @@ const HIGHEST_SECTIONS = ['active', 'next'];
 const SectionBar = ({ activeSection, onSectionChange, isLive, isHighestPredictedTeam }) => {
   const theme = useTheme();
   const sections = isHighestPredictedTeam ? HIGHEST_SECTIONS : USER_SECTIONS;
-  const value = Math.max(0, sections.indexOf(activeSection));
+  const activeIndex = sections.indexOf(activeSection);
+
+  React.useEffect(() => {
+    if (activeIndex === -1) onSectionChange(sections[0]);
+  }, [activeIndex, onSectionChange, sections]);
 
   return (
     <Box
@@ -30,7 +34,7 @@ const SectionBar = ({ activeSection, onSectionChange, isLive, isHighestPredicted
       } }
     >
       <Tabs
-        value={ value }
+        value={ activeIndex === -1 ? false : activeIndex }
         onChange={ (_, newValue) => onSectionChange(sections[newValue]) }
         centered
         sx={ {

--- a/frontend/src/components/SectionBar/SectionBar.jsx
+++ b/frontend/src/components/SectionBar/SectionBar.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Badge from '@mui/material/Badge';
+import { useTheme } from '@mui/material/styles';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
+import SkipNextIcon from '@mui/icons-material/SkipNext';
+
+const USER_SECTIONS = ['active', 'planning', 'overview'];
+const HIGHEST_SECTIONS = ['active', 'next'];
+
+const SectionBar = ({ activeSection, onSectionChange, isLive, isHighestPredictedTeam }) => {
+  const theme = useTheme();
+  const sections = isHighestPredictedTeam ? HIGHEST_SECTIONS : USER_SECTIONS;
+  const value = Math.max(0, sections.indexOf(activeSection));
+
+  return (
+    <Box
+      sx={ {
+        backgroundColor: theme.palette.background.paper,
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        '@keyframes livePulse': {
+          '0%, 100%': { opacity: 1 },
+          '50%': { opacity: 0.3 },
+        },
+      } }
+    >
+      <Tabs
+        value={ value }
+        onChange={ (_, newValue) => onSectionChange(sections[newValue]) }
+        centered
+        sx={ {
+          minHeight: 44,
+          '& .MuiTab-root': {
+            minHeight: 44,
+            py: 0.75,
+            textTransform: 'none',
+            fontWeight: 600,
+            fontSize: '0.875rem',
+          },
+        } }
+      >
+        <Tab
+          icon={
+            <Badge
+              variant='dot'
+              color='success'
+              invisible={ !isLive }
+              sx={ {
+                '& .MuiBadge-dot': isLive ? {
+                  animation: 'livePulse 1.5s ease-in-out infinite',
+                } : {},
+              } }
+            >
+              <SportsSoccerIcon sx={ { fontSize: 18 } } />
+            </Badge>
+          }
+          iconPosition='start'
+          label='Active'
+        />
+        { isHighestPredictedTeam ? (
+          <Tab
+            icon={ <SkipNextIcon sx={ { fontSize: 18 } } /> }
+            iconPosition='start'
+            label='Next'
+          />
+        ) : (
+          <Tab
+            icon={ <EventNoteIcon sx={ { fontSize: 18 } } /> }
+            iconPosition='start'
+            label='Planning'
+          />
+        ) }
+        { !isHighestPredictedTeam && (
+          <Tab
+            icon={ <BarChartIcon sx={ { fontSize: 18 } } /> }
+            iconPosition='start'
+            label='Overview'
+          />
+        ) }
+      </Tabs>
+    </Box>
+  );
+};
+
+SectionBar.propTypes = {
+  activeSection: PropTypes.string.isRequired,
+  onSectionChange: PropTypes.func.isRequired,
+  isLive: PropTypes.bool,
+  isHighestPredictedTeam: PropTypes.bool,
+};
+
+export default SectionBar;

--- a/frontend/src/components/SectionBar/index.js
+++ b/frontend/src/components/SectionBar/index.js
@@ -1,0 +1,1 @@
+export { default } from './SectionBar';

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -23,6 +23,7 @@ const TeamActivityPanel = ({
   allPlayers,
   voidedTransferIds,
   freeHitGWs,
+  activeSection,
 }) => {
   const theme = useTheme();
   const [profile, setProfile] = useState(null);
@@ -208,7 +209,7 @@ const TeamActivityPanel = ({
       ) }
 
       { /* My Leagues - between Team Stats and Recent Performance */ }
-      { entryId && profile && (myInvLeagues.length > 0 || myGenLeagues.length > 0) && (
+      { entryId && profile && activeSection === 'overview' && (myInvLeagues.length > 0 || myGenLeagues.length > 0) && (
         <Paper sx={ { backgroundColor: theme.palette.background.paper, borderRadius: 1, p: 2, flex: '0 0 auto' } }>
           <Typography variant='h6' sx={ { mb: 1.5, fontWeight: 600 } }>My Leagues</Typography>
           <Box sx={ { display: 'flex', gap: 2 } }>
@@ -316,51 +317,8 @@ const TeamActivityPanel = ({
       </Paper>
       ) }
 
-      { /* Recommended Transfers - Bottom Section */ }
-      { currentEntryId && !viewingOpponentId && currentGameweek && (
-        <Paper
-          sx={ {
-            backgroundColor: theme.palette.background.paper,
-            borderRadius: 1,
-            p: 2,
-            flex: '0 0 auto',
-          } }
-        >
-          <RecommendedTransfers
-            entryId={ currentEntryId }
-            currentGameweek={ currentGameweek }
-            compact={ true }
-          />
-        </Paper>
-      ) }
-
-      { /* Planned Transfers Section – shown for own team only */ }
-      { currentEntryId && !viewingOpponentId && currentGameweek && onAddPlannedTransfer && (
-        <Paper
-          sx={ {
-            backgroundColor: theme.palette.background.paper,
-            borderRadius: 1,
-            p: 2,
-            flex: '0 0 auto',
-          } }
-        >
-          <PlannedTransfers
-            plannedTransfers={ plannedTransfers }
-            onRemove={ onRemovePlannedTransfer }
-            onUpdateGameweek={ onUpdatePlannedTransferGameweek }
-            onAdd={ onAddPlannedTransfer }
-            team={ team }
-            allPlayers={ allPlayers }
-            currentGameweek={ currentGameweek }
-            compact={ true }
-            voidedTransferIds={ voidedTransferIds }
-            freeHitGWs={ freeHitGWs }
-          />
-        </Paper>
-      ) }
-
-      { /* Assistant Manager – always shown (general hints if no entryId) */ }
-      { currentGameweek && (
+      { /* Assistant Manager – shown in Planning section */ }
+      { activeSection === 'planning' && currentGameweek && (
         <Paper
           sx={ {
             backgroundColor: theme.palette.background.paper,
@@ -392,6 +350,7 @@ TeamActivityPanel.propTypes = {
   allPlayers: PropTypes.array,
   voidedTransferIds: PropTypes.instanceOf(Set),
   freeHitGWs: PropTypes.instanceOf(Set),
+  activeSection: PropTypes.string,
 };
 
 export default TeamActivityPanel;

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -24,6 +24,7 @@ const TeamActivityPanel = ({
   voidedTransferIds,
   freeHitGWs,
   activeSection,
+  isCurrentGwActive,
 }) => {
   const theme = useTheme();
   const [profile, setProfile] = useState(null);
@@ -62,8 +63,11 @@ const TeamActivityPanel = ({
     return n.toString();
   };
 
-  // Get recent gameweeks (last 5)
-  const recentHistory = history.slice(-5).reverse();
+  // Exclude the current GW from recent form while it's still active (scores are partial)
+  const recentHistory = history
+    .filter(h => !(isCurrentGwActive && h.event === currentGameweek))
+    .slice(-5)
+    .reverse();
 
   // Average points across all history for colour coding
   const avgPoints = history.length
@@ -213,7 +217,18 @@ const TeamActivityPanel = ({
                   Recent Form
                 </Typography>
                 <Box sx={ { display: 'flex', gap: 0.75 } }>
-                  { recentHistory.slice().reverse().map((gw) => (
+                  { recentHistory.slice().reverse().map((gw) => {
+                    const prevGw = history.find(h => h.event === gw.event - 1);
+                    // Lower rank number = better. Green if rank improved (fell), red if worsened (rose).
+                    let rankColor = theme.palette.text.secondary;
+                    if (prevGw?.overall_rank != null && gw.overall_rank != null) {
+                      rankColor = gw.overall_rank < prevGw.overall_rank
+                        ? theme.palette.success.main
+                        : gw.overall_rank > prevGw.overall_rank
+                          ? theme.palette.error.main
+                          : theme.palette.text.secondary;
+                    }
+                    return (
                     <Box
                       key={ gw.event }
                       sx={ {
@@ -234,18 +249,16 @@ const TeamActivityPanel = ({
                       <Typography
                         variant='body2'
                         fontWeight='700'
-                        sx={ {
-                          lineHeight: 1,
-                          color: gw.points >= avgPoints ? theme.palette.success.main : theme.palette.error.main,
-                        } }
+                        sx={ { lineHeight: 1, color: rankColor } }
                       >
                         { gw.points }
                       </Typography>
-                      <Typography variant='caption' color='text.secondary' sx={ { fontSize: '0.6rem', lineHeight: 1 } }>
+                      <Typography variant='caption' sx={ { fontSize: '0.6rem', lineHeight: 1, color: rankColor } }>
                         { formatRank(gw.overall_rank) }
                       </Typography>
                     </Box>
-                  )) }
+                    );
+                  }) }
                 </Box>
               </>
             ) }
@@ -334,6 +347,7 @@ TeamActivityPanel.propTypes = {
   voidedTransferIds: PropTypes.instanceOf(Set),
   freeHitGWs: PropTypes.instanceOf(Set),
   activeSection: PropTypes.string,
+  isCurrentGwActive: PropTypes.bool,
 };
 
 export default TeamActivityPanel;

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -92,7 +92,7 @@ const TeamActivityPanel = ({
         overflow: 'auto',
       } }
     >
-      { /* Team Stats - Top Section */ }
+      { /* Team Stats + Recent Performance - Top Section */ }
       { entryId && profile && (
         <Paper
           sx={ {
@@ -204,6 +204,51 @@ const TeamActivityPanel = ({
                 })() }
               </Box>
             </Box>
+
+            { /* Recent Performance - condensed inline */ }
+            { recentHistory.length > 0 && (
+              <>
+                <Divider />
+                <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>
+                  Recent Form
+                </Typography>
+                <Box sx={ { display: 'flex', gap: 0.75 } }>
+                  { recentHistory.slice().reverse().map((gw) => (
+                    <Box
+                      key={ gw.event }
+                      sx={ {
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 0.25,
+                        py: 0.5,
+                        px: 0.25,
+                        borderRadius: 1,
+                        backgroundColor: theme.palette.action.hover,
+                      } }
+                    >
+                      <Typography variant='caption' color='text.secondary' sx={ { fontSize: '0.6rem', lineHeight: 1 } }>
+                        GW{ gw.event }
+                      </Typography>
+                      <Typography
+                        variant='body2'
+                        fontWeight='700'
+                        sx={ {
+                          lineHeight: 1,
+                          color: gw.points >= avgPoints ? theme.palette.success.main : theme.palette.error.main,
+                        } }
+                      >
+                        { gw.points }
+                      </Typography>
+                      <Typography variant='caption' color='text.secondary' sx={ { fontSize: '0.6rem', lineHeight: 1 } }>
+                        { formatRank(gw.overall_rank) }
+                      </Typography>
+                    </Box>
+                  )) }
+                </Box>
+              </>
+            ) }
           </Box>
         </Paper>
       ) }
@@ -253,68 +298,6 @@ const TeamActivityPanel = ({
             ) }
           </Box>
         </Paper>
-      ) }
-
-      { /* Recent Performance - Middle Section */ }
-      { entryId && (
-      <Paper
-        sx={ {
-          backgroundColor: theme.palette.background.paper,
-          borderRadius: 1,
-          p: 2,
-          flex: '0 0 auto',
-        } }
-      >
-        <Typography variant='h6' sx={ { mb: 1.5, fontWeight: 600 } }>
-          Recent Performance
-        </Typography>
-        { recentHistory.length === 0 ? (
-          <Typography variant='body2' color='text.secondary'>No recent gameweeks</Typography>
-        ) : (
-          <Box>
-            { /* Header row */ }
-            <Box sx={ { display: 'grid', gridTemplateColumns: '3rem 1fr 1fr 1fr', gap: 0.5, px: 1, mb: 0.5 } }>
-              <Typography variant='caption' color='text.secondary'>GW</Typography>
-              <Typography variant='caption' color='text.secondary' sx={ { textAlign: 'right' } }>Pts</Typography>
-              <Typography variant='caption' color='text.secondary' sx={ { textAlign: 'right' } }>Rank</Typography>
-              <Typography variant='caption' color='text.secondary' sx={ { textAlign: 'right' } }>Value</Typography>
-            </Box>
-            <Divider sx={ { mb: 0.5 } } />
-            { recentHistory.map((gw) => (
-              <Box
-                key={ gw.event }
-                sx={ {
-                  display: 'grid',
-                  gridTemplateColumns: '3rem 1fr 1fr 1fr',
-                  gap: 0.5,
-                  px: 1,
-                  py: 0.75,
-                  borderRadius: 1,
-                  '&:hover': { backgroundColor: theme.palette.action.hover },
-                } }
-              >
-                <Typography variant='body2' fontWeight='600'>{ gw.event }</Typography>
-                <Typography
-                  variant='body2'
-                  fontWeight='600'
-                  sx={ {
-                    textAlign: 'right',
-                    color: gw.points >= avgPoints ? theme.palette.success.main : theme.palette.error.main,
-                  } }
-                >
-                  { gw.points }
-                </Typography>
-                <Typography variant='body2' sx={ { textAlign: 'right', fontSize: '0.75rem' } }>
-                  { formatRank(gw.overall_rank) }
-                </Typography>
-                <Typography variant='body2' sx={ { textAlign: 'right', fontSize: '0.75rem' } }>
-                  { formatCurrency(gw.value) }
-                </Typography>
-              </Box>
-            )) }
-          </Box>
-        ) }
-      </Paper>
       ) }
 
       { /* Assistant Manager – shown in Planning section */ }

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -6,23 +6,12 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import RemoveIcon from '@mui/icons-material/Remove';
 import axios from '../../api';
-import RecommendedTransfers from '../RecommendedTransfers';
-import PlannedTransfers from '../PlannedTransfers';
 import AssistantManagerPanel from '../AssistantManagerPanel';
 
 const TeamActivityPanel = ({
   entryId,
   currentGameweek,
-  currentEntryId,
   viewingOpponentId,
-  plannedTransfers,
-  onRemovePlannedTransfer,
-  onUpdatePlannedTransferGameweek,
-  onAddPlannedTransfer,
-  team,
-  allPlayers,
-  voidedTransferIds,
-  freeHitGWs,
   activeSection,
   isCurrentGwActive,
 }) => {
@@ -66,8 +55,7 @@ const TeamActivityPanel = ({
   // Exclude the current GW from recent form while it's still active (scores are partial)
   const recentHistory = history
     .filter(h => !(isCurrentGwActive && h.event === currentGameweek))
-    .slice(-5)
-    .reverse();
+    .slice(-5);
 
   // Average points across all history for colour coding
   const avgPoints = history.length
@@ -217,7 +205,7 @@ const TeamActivityPanel = ({
                   Recent Form
                 </Typography>
                 <Box sx={ { display: 'flex', gap: 0.75 } }>
-                  { recentHistory.slice().reverse().map((gw) => {
+                  { recentHistory.map((gw) => {
                     const prevGw = history.find(h => h.event === gw.event - 1);
                     // Lower rank number = better. Green if rank improved (fell), red if worsened (rose).
                     let rankColor = theme.palette.text.secondary;
@@ -336,16 +324,7 @@ const TeamActivityPanel = ({
 TeamActivityPanel.propTypes = {
   entryId: PropTypes.string,
   currentGameweek: PropTypes.number,
-  currentEntryId: PropTypes.string,
   viewingOpponentId: PropTypes.string,
-  plannedTransfers: PropTypes.array,
-  onRemovePlannedTransfer: PropTypes.func,
-  onUpdatePlannedTransferGameweek: PropTypes.func,
-  onAddPlannedTransfer: PropTypes.func,
-  team: PropTypes.array,
-  allPlayers: PropTypes.array,
-  voidedTransferIds: PropTypes.instanceOf(Set),
-  freeHitGWs: PropTypes.instanceOf(Set),
   activeSection: PropTypes.string,
   isCurrentGwActive: PropTypes.bool,
 };


### PR DESCRIPTION
This pull request introduces a significant performance improvement to the backend by adding a simple in-memory cache for FPL API requests, reducing redundant network calls. On the frontend, it adds a new section navigation bar, refines the user experience for switching between team views and gameweeks, and introduces a dedicated planning section with planned and recommended transfers. The navigation and panel components are updated to respect the new section logic and lock gameweek selection when appropriate.

**Backend: FPL API caching**

- Added an in-memory TTL cache (`cachedGet`) to `dataProvider.js` to avoid repeated FPL API requests, with configurable TTLs for different endpoints. All FPL API fetch functions now use this cache, reducing latency and API load. [[1]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eR6-R33) [[2]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL40-R68) [[3]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL61-R88) [[4]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL80-R106) [[5]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL95-R120) [[6]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL112-R136) [[7]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL132-R155) [[8]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL151-R173) [[9]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL170-R191) [[10]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL187-R207) [[11]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eL207-R226)

**Frontend: Section navigation and planning**

- Introduced `SectionBar` and new section state (`activeSection`) in `App.jsx`, allowing users to switch between "active", "planning", and other views. The UI now auto-switches sections based on context (e.g., when a gameweek goes live or when switching teams), and tracks user overrides. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R57-R59) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R217-R266) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R599-R605)
- Added a dedicated "Planning" section in the middle panel, displaying `PlannedTransfers` and `RecommendedTransfers` components when appropriate.
- Updated `RightPanel`, `TeamActivityPanel`, and navigation components to receive and respect the `activeSection` prop, ensuring consistent behavior and UI state across the app. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R843-R845) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R863) [[3]](diffhunk://#diff-141a1192db60f4b7255efb2fbc666e0676828408130fcb93b559c75844903a8bR24) [[4]](diffhunk://#diff-141a1192db60f4b7255efb2fbc666e0676828408130fcb93b559c75844903a8bR134)

**Frontend: Gameweek selection locking**

- Modified `NavigationBar` to disable and clarify gameweek selection controls when the section requires the gameweek to be locked (e.g., "Active" or "Next" views), improving user feedback and preventing inconsistent state. [[1]](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134R42) [[2]](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134L167-R173) [[3]](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134R190) [[4]](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134L202-R209)

**Other frontend improvements**

- Only display the `LiveBanner` when in the "Active" section, preventing confusion in other contexts.

These changes improve performance, user experience, and code clarity across the application.