### PR TITLE
Enhance Invitation League standings and opponent team details

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -65,23 +65,6 @@ const App = () => {
   const userOverriddenSection = useRef(false);
   const prevGameweekRef = useRef(null);
 
-  const handleChipToggle = (chipId) => {
-    const next = activeChip === chipId ? null : chipId;
-    setActiveChip(next);
-    const viewedGW = gameweekInfo?.selected;
-    if (!isHighestPredictedTeam && !isLockedGameweek && userEntryId && viewedGW) {
-      // Persist planned chip per-gameweek so it survives page refreshes.
-      // Only stored for future GWs — locked GWs read chip state from FPL directly.
-      saveChip(userEntryId, viewedGW, next);
-      setPlannedChipsByGW(prev => {
-        const updated = { ...prev };
-        if (next) updated[viewedGW] = next;
-        else delete updated[viewedGW];
-        return updated;
-      });
-    }
-  };
-
   const {
     activePlayers,
     reservePlayers,
@@ -106,6 +89,41 @@ const App = () => {
   );
 
   const { allPlayers } = useAllPlayers(selectedGameweek);
+
+  const handleChipToggle = (chipId) => {
+    const next = activeChip === chipId ? null : chipId;
+    setActiveChip(next);
+    const viewedGW = gameweekInfo?.selected;
+    const locked = !!(gameweekInfo?.isActive || gameweekInfo?.isPast);
+    if (!isHighestPredictedTeam && !locked && userEntryId && viewedGW) {
+      // Persist planned chip per-gameweek so it survives page refreshes.
+      // Only stored for future GWs — locked GWs read chip state from FPL directly.
+      saveChip(userEntryId, viewedGW, next);
+      setPlannedChipsByGW(prev => {
+        const updated = { ...prev };
+        if (next) updated[viewedGW] = next;
+        else delete updated[viewedGW];
+        return updated;
+      });
+    }
+  };
+
+  // Toggle a chip for a specific future GW from the PlannedTransfers panel.
+  // Unlike handleChipToggle (which uses the currently viewed GW), this accepts
+  // the target GW explicitly so chips can be planned for any future GW at once.
+  const handlePlannedChipToggle = useCallback((chipId, gw) => {
+    const current = plannedChipsByGW[gw];
+    const next = current === chipId ? null : chipId;
+    if (userEntryId) saveChip(userEntryId, gw, next);
+    setPlannedChipsByGW(prev => {
+      const updated = { ...prev };
+      if (next) updated[gw] = next;
+      else delete updated[gw];
+      return updated;
+    });
+    // Sync transient activeChip if the toggled GW is the one currently in view.
+    if (gw === gameweekInfo?.selected) setActiveChip(next);
+  }, [plannedChipsByGW, userEntryId, gameweekInfo?.selected]);
 
   // Squad team names used to filter relevant ESPN score change notifications.
   const squadTeamNames = useMemo(() => {
@@ -139,9 +157,11 @@ const App = () => {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [localSnackbar, setLocalSnackbar] = useState('');
   const [usedFplChips, setUsedFplChips] = useState([]); // chip names from FPL profile e.g. ['bboost', '3xc']
+  const [fplChipsHistory, setFplChipsHistory] = useState([]); // { name, event }[] – full chip records from FPL profile
 
-  // Map our chip IDs to FPL API chip names
+  // Map our chip IDs to FPL API chip names (and the reverse)
   const FPL_CHIP_KEY = { bench_boost: 'bboost', triple_captain: '3xc', free_hit: 'freehit', wildcard: 'wildcard' };
+  const FPL_TO_CHIP_ID = { bboost: 'bench_boost', '3xc': 'triple_captain', freehit: 'free_hit', wildcard: 'wildcard' };
 
   // Each chip can be used at most 2× (one per half-season). Unused = used < 2 times.
   const unusedChipIds = useMemo(
@@ -149,12 +169,19 @@ const App = () => {
     [usedFplChips]
   );
 
-  // Fetch used chips from FPL profile whenever we have a real user entry
+  // Fetch used chips from FPL profile whenever we have a real user entry.
+  // Also stores the full chip objects (with event/GW number) for badge display.
+  // When viewingOpponentId is set, currentEntryId equals the opponent's ID so
+  // fplChipsHistory will contain the opponent's chip history automatically.
   useEffect(() => {
-    if (!currentEntryId || isHighestPredictedTeam) { setUsedFplChips([]); return; }
+    if (!currentEntryId || isHighestPredictedTeam) { setUsedFplChips([]); setFplChipsHistory([]); return; }
     axios.get(`/api/entry/${currentEntryId}/profile`)
-      .then(res => setUsedFplChips((res.data.chips || []).map(c => c.name)))
-      .catch(() => setUsedFplChips([]));
+      .then(res => {
+        const chips = res.data.chips || [];
+        setUsedFplChips(chips.map(c => c.name));
+        setFplChipsHistory(chips);
+      })
+      .catch(() => { setUsedFplChips([]); setFplChipsHistory([]); });
   }, [currentEntryId, isHighestPredictedTeam]);
 
   // Load all future GW planned chips from localStorage into state whenever the
@@ -220,6 +247,26 @@ const App = () => {
     // Prefer a planned per-gameweek chip (persisted to storage), fallback to transient `activeChip`.
     return plannedChipsByGW[viewedGW] ?? activeChip ?? null;
   }, [gameweekInfo, isHighestPredictedTeam, viewingOpponentId, plannedChipsByGW, activeChip]);
+
+  // Chip used/planned for the currently viewed GW — used to display a badge beside
+  // the Total Points figure in the stats pod across all sections (active/planned/overview).
+  // For own team future GW: reflects the planned chip.  For locked/past own GW or any
+  // opponent GW: resolved from FPL profile chip history (fplChipsHistory contains the
+  // opponent's history when viewingOpponentId is set, because currentEntryId is set to
+  // the opponent's ID which triggers a re-fetch of the profile endpoint).
+  const viewedGwChip = useMemo(() => {
+    if (isHighestPredictedTeam) return null;
+    const viewedGW = gameweekInfo?.selected ?? currentGameweek;
+    if (!viewedGW) return null;
+    // Future GW for own team: use the planned/active chip.
+    if (!viewingOpponentId && gameweekInfo?.isFuture) return effectiveActiveChip;
+    // Locked own GW or any opponent GW: look up from FPL chip history.
+    const played = fplChipsHistory.find(c => c.event === viewedGW);
+    return played ? (FPL_TO_CHIP_ID[played.name] ?? null) : null;
+  }, [isHighestPredictedTeam, viewingOpponentId, gameweekInfo, currentGameweek, effectiveActiveChip, fplChipsHistory]);
+
+  // Chip display metadata (label, colour, description) for the viewed GW chip.
+  const viewedGwChipData = CHIPS.find(c => c.id === viewedGwChip) ?? null;
 
   // Reset section when switching between user and highest team
   const prevIsHighestRef = useRef(isHighestPredictedTeam);
@@ -454,18 +501,22 @@ const App = () => {
       : Math.round((cap.predictedPoints ?? 0) / (cap.multiplier || 2));
   }, [effectiveActivePlayers]);
 
-  // Points displayed in the stats pod — adjusted for the effective chip for the viewed GW
+  // Points displayed in the stats pod — adjusted for the effective chip for the viewed GW.
+  // effectiveActiveChip covers future GWs; viewedGwChip also covers active/historic GWs
+  // (e.g. Bench Boost already played — bench points should be merged into total).
   const displayTotalPoints = useMemo(() => {
     const active = calculateTotalPredictedPoints(effectiveActivePlayers);
-    if (effectiveActiveChip === 'bench_boost') return active + calculateTotalPredictedPoints(effectiveReservePlayers);
-    if (effectiveActiveChip === 'triple_captain') return active + captainBasePoints; // +1× extra → 3× total
+    const chipInEffect = effectiveActiveChip ?? viewedGwChip;
+    if (chipInEffect === 'bench_boost') return active + calculateTotalPredictedPoints(effectiveReservePlayers);
+    if (chipInEffect === 'triple_captain') return active + captainBasePoints; // +1× extra → 3× total
     return active;
-  }, [effectiveActiveChip, effectiveActivePlayers, effectiveReservePlayers, calculateTotalPredictedPoints, captainBasePoints]);
+  }, [effectiveActiveChip, viewedGwChip, effectiveActivePlayers, effectiveReservePlayers, calculateTotalPredictedPoints, captainBasePoints]);
 
   const displayBenchPoints = useMemo(() => {
-    if (effectiveActiveChip === 'bench_boost') return 0; // bench points are merged into total
+    const chipInEffect = effectiveActiveChip ?? viewedGwChip;
+    if (chipInEffect === 'bench_boost') return 0; // bench points are merged into total
     return calculateTotalPredictedPoints(effectiveReservePlayers);
-  }, [effectiveActiveChip, effectiveReservePlayers, calculateTotalPredictedPoints]);
+  }, [effectiveActiveChip, viewedGwChip, effectiveReservePlayers, calculateTotalPredictedPoints]);
 
   // Free Transfers remaining for the viewed GW, after planned transfers are applied.
   // null = not applicable (highest predicted team or opponent view).
@@ -772,6 +823,27 @@ const App = () => {
                         ? <ArrowUpwardIcon sx={ { fontSize: 16, color: 'success.main' } } />
                         : <ArrowDownwardIcon sx={ { fontSize: 16, color: 'error.main' } } />
                     ) }
+                    { viewedGwChipData && (
+                      <Tooltip title={ `${ viewingOpponentId ? 'Opponent chip — ' : '' }${ viewedGwChipData.name }: ${ viewedGwChipData.description }` }>
+                        <Box
+                          component='span'
+                          sx={ {
+                            px: 0.6, py: '1px',
+                            borderRadius: '3px',
+                            backgroundColor: viewedGwChipData.color,
+                            color: '#fff',
+                            fontSize: '0.6rem',
+                            fontWeight: 700,
+                            lineHeight: 1.6,
+                            cursor: 'default',
+                            flexShrink: 0,
+                            ml: 0.25,
+                          } }
+                        >
+                          { viewedGwChipData.label }
+                        </Box>
+                      </Tooltip>
+                    ) }
                   </Box>
                   <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>
                     { displayBenchPoints }
@@ -885,6 +957,9 @@ const App = () => {
                       compact={ false }
                       voidedTransferIds={ voidedTransferIds }
                       freeHitGWs={ freeHitGWs }
+                      plannedChipsByGW={ plannedChipsByGW }
+                      unusedChipIds={ unusedChipIds }
+                      onChipToggle={ handlePlannedChipToggle }
                     />
                   </Paper>
                 ) }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import GridViewIcon from '@mui/icons-material/GridView';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Tooltip from '@mui/material/Tooltip';
 import TeamFormation from './components/TeamFormation/TeamFormation';
 import TeamListView from './components/TeamListView/TeamListView';
@@ -51,6 +52,8 @@ const App = () => {
   const [selectedGameweek, setSelectedGameweek] = useState(null); // null means current gameweek
   const [currentGameweek, setCurrentGameweek] = useState(null);
   const [viewingOpponentId, setViewingOpponentId] = useState(null); // opponent team being viewed
+  const [viewingOpponentTeamName, setViewingOpponentTeamName] = useState('');
+  const [viewingOpponentPlayerName, setViewingOpponentPlayerName] = useState('');
   const [pitchView, setPitchView] = useState(() => localStorage.getItem('pitchView') || 'formation'); // 'formation' | 'list'
   const [activeChip, setActiveChip] = useState(null); // 'bench_boost' | 'triple_captain' | 'free_hit' | 'wildcard' | null
   // Planned chips across all future GWs: { [gw]: chipId }.  Loaded from storage
@@ -537,9 +540,22 @@ const App = () => {
   }, [userEntryId, teamView, viewingOpponentId]);
 
   // Handle clicking an opponent's team name from the league view
-  const handleViewOpponentTeam = (opponentEntryId) => {
+  const handleViewOpponentTeam = (opponentEntryId, opponentTeamName = '', opponentPlayerName = '') => {
+    const isOwnTeam = userEntryId && String(opponentEntryId) === String(userEntryId);
+    if (isOwnTeam) {
+      // Clicking own team in standings — just switch to My Team view, no banner
+      setViewingOpponentId(null);
+      setViewingOpponentTeamName('');
+      setViewingOpponentPlayerName('');
+      setCurrentEntryId(userEntryId);
+      setTeamView(TEAM_VIEW.USER);
+      if (isHighestPredictedTeam) toggleTeamView();
+      return;
+    }
     setViewingOpponentId(String(opponentEntryId));
     setCurrentEntryId(String(opponentEntryId));
+    setViewingOpponentTeamName(opponentTeamName);
+    setViewingOpponentPlayerName(opponentPlayerName);
     setTeamView(TEAM_VIEW.USER);
     if (isHighestPredictedTeam) toggleTeamView();
   };
@@ -547,6 +563,8 @@ const App = () => {
   // Return from viewing an opponent's team back to the user's own team
   const handleBackToMyTeam = () => {
     setViewingOpponentId(null);
+    setViewingOpponentTeamName('');
+    setViewingOpponentPlayerName('');
     setCurrentEntryId(userEntryId);
   };
 
@@ -624,13 +642,43 @@ const App = () => {
           <Box sx={ { flex: { xs: '1 1 auto', lg: '0 0 43%' }, width: { xs: '100%', lg: 'auto' }, display: 'flex', flexDirection: 'column' } }>
             { /* Banner shown when viewing an opponent's team */ }
             { viewingOpponentId && (
-              <Box sx={ { mb: 1, display: 'flex', alignItems: 'center', gap: 1 } }>
-                <Typography variant='body2' color='text.secondary'>
-                  Viewing opponent&apos;s team
-                </Typography>
+              <Box
+                sx={ {
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  px: 1.5,
+                  py: 1,
+                  borderRadius: 1,
+                  borderLeft: '3px solid',
+                  borderLeftColor: 'warning.main',
+                  bgcolor: 'action.hover',
+                } }
+              >
+                <Box sx={ { flex: 1, minWidth: 0 } }>
+                  <Typography variant='caption' color='warning.main' fontWeight={ 700 } sx={ { textTransform: 'uppercase', letterSpacing: '0.06em' } }>
+                    Viewing opponent
+                  </Typography>
+                  <Typography variant='body2' fontWeight={ 600 } noWrap>
+                    { viewingOpponentTeamName || teamName || 'Opponent’s Team' }
+                  </Typography>
+                  { viewingOpponentPlayerName && (
+                    <Typography variant='caption' color='text.secondary' noWrap>
+                      { viewingOpponentPlayerName }
+                    </Typography>
+                  ) }
+                </Box>
                 { userEntryId && (
-                  <Button size='small' variant='outlined' onClick={ handleBackToMyTeam }>
-                    Back to My Team
+                  <Button
+                    size='small'
+                    variant='outlined'
+                    color='warning'
+                    startIcon={ <ArrowBackIcon fontSize='small' /> }
+                    onClick={ handleBackToMyTeam }
+                    sx={ { whiteSpace: 'nowrap', flexShrink: 0 } }
+                  >
+                    My Team
                   </Button>
                 ) }
               </Box>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import axios from './api';
 import { saveChip, loadChip } from './utils/lineupStorage';
 import { computeProjectedBank, simulateFreeTransferCarryover } from './utils/freeHitSimulation';
+import { CHIPS, CHIP_ID_TO_FPL, FPL_TO_CHIP_ID } from './constants/chips';
 import NavigationBar from './components/NavigationBar/NavigationBar';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
@@ -36,13 +37,6 @@ const TEAM_VIEW = {
   USER: 'user',
   HIGHEST: 'highest'
 };
-
-const CHIPS = [
-  { id: 'bench_boost',    label: 'BB', name: 'Bench Boost',    description: 'Bench points are added to your total',            color: '#2e7d32' },
-  { id: 'triple_captain', label: 'TC', name: 'Triple Captain', description: '3× captain multiplier instead of 2×',             color: '#1565c0' },
-  { id: 'free_hit',       label: 'FH', name: 'Free Hit',       description: 'Unlimited free transfers — reverts next week',    color: '#e65100' },
-  { id: 'wildcard',       label: 'WC', name: 'Wildcard',       description: 'All transfers are free and permanent',            color: '#6a1b9a' },
-];
 
 const App = () => {
   const theme = useTheme();
@@ -108,23 +102,6 @@ const App = () => {
     }
   };
 
-  // Toggle a chip for a specific future GW from the PlannedTransfers panel.
-  // Unlike handleChipToggle (which uses the currently viewed GW), this accepts
-  // the target GW explicitly so chips can be planned for any future GW at once.
-  const handlePlannedChipToggle = useCallback((chipId, gw) => {
-    const current = plannedChipsByGW[gw];
-    const next = current === chipId ? null : chipId;
-    if (userEntryId) saveChip(userEntryId, gw, next);
-    setPlannedChipsByGW(prev => {
-      const updated = { ...prev };
-      if (next) updated[gw] = next;
-      else delete updated[gw];
-      return updated;
-    });
-    // Sync transient activeChip if the toggled GW is the one currently in view.
-    if (gw === gameweekInfo?.selected) setActiveChip(next);
-  }, [plannedChipsByGW, userEntryId, gameweekInfo?.selected]);
-
   // Squad team names used to filter relevant ESPN score change notifications.
   const squadTeamNames = useMemo(() => {
     const names = new Set();
@@ -159,13 +136,9 @@ const App = () => {
   const [usedFplChips, setUsedFplChips] = useState([]); // chip names from FPL profile e.g. ['bboost', '3xc']
   const [fplChipsHistory, setFplChipsHistory] = useState([]); // { name, event }[] – full chip records from FPL profile
 
-  // Map our chip IDs to FPL API chip names (and the reverse)
-  const FPL_CHIP_KEY = { bench_boost: 'bboost', triple_captain: '3xc', free_hit: 'freehit', wildcard: 'wildcard' };
-  const FPL_TO_CHIP_ID = { bboost: 'bench_boost', '3xc': 'triple_captain', freehit: 'free_hit', wildcard: 'wildcard' };
-
   // Each chip can be used at most 2× (one per half-season). Unused = used < 2 times.
   const unusedChipIds = useMemo(
-    () => CHIPS.filter(c => usedFplChips.filter(n => n === FPL_CHIP_KEY[c.id]).length < 2).map(c => c.id),
+    () => CHIPS.filter(c => usedFplChips.filter(n => n === CHIP_ID_TO_FPL[c.id]).length < 2).map(c => c.id),
     [usedFplChips]
   );
 
@@ -214,6 +187,27 @@ const App = () => {
     if (activeChip && !unusedChipIds.includes(activeChip)) setActiveChip(null);
   }, [unusedChipIds, activeChip]);
 
+  // Toggle a chip for a specific future GW from the PlannedTransfers panel.
+  // Unlike handleChipToggle (which uses the currently viewed GW), this accepts
+  // the target GW explicitly so chips can be planned for any future GW at once.
+  // Guards: only persists for future GWs and chips still available to the user.
+  const handlePlannedChipToggle = useCallback((chipId, gw) => {
+    if (!gw || gw <= currentGameweek) return;
+    const current = plannedChipsByGW[gw];
+    const next = current === chipId ? null : chipId;
+    // Only allow toggling on if the chip is still unused (clearing is always OK).
+    if (next && !unusedChipIds.includes(next)) return;
+    if (userEntryId) saveChip(userEntryId, gw, next);
+    setPlannedChipsByGW(prev => {
+      const updated = { ...prev };
+      if (next) updated[gw] = next;
+      else delete updated[gw];
+      return updated;
+    });
+    // Sync transient activeChip if the toggled GW is the one currently in view.
+    if (gw === gameweekInfo?.selected) setActiveChip(next);
+  }, [plannedChipsByGW, currentGameweek, unusedChipIds, userEntryId, gameweekInfo?.selected]);
+
   // Track the last gameweek we restored a chip for, so we only do it once per
   // gameweek/entry combination and don't clobber a manual toggle on re-render.
   const restoredChipKey = useRef(null);
@@ -258,12 +252,14 @@ const App = () => {
     if (isHighestPredictedTeam) return null;
     const viewedGW = gameweekInfo?.selected ?? currentGameweek;
     if (!viewedGW) return null;
-    // Future GW for own team: use the planned/active chip.
-    if (!viewingOpponentId && gameweekInfo?.isFuture) return effectiveActiveChip;
+    // Future GW for own team: use the planned/active chip (only if still available).
+    if (!viewingOpponentId && gameweekInfo?.isFuture) {
+      return unusedChipIds.includes(effectiveActiveChip) ? effectiveActiveChip : null;
+    }
     // Locked own GW or any opponent GW: look up from FPL chip history.
     const played = fplChipsHistory.find(c => c.event === viewedGW);
     return played ? (FPL_TO_CHIP_ID[played.name] ?? null) : null;
-  }, [isHighestPredictedTeam, viewingOpponentId, gameweekInfo, currentGameweek, effectiveActiveChip, fplChipsHistory]);
+  }, [isHighestPredictedTeam, viewingOpponentId, gameweekInfo, currentGameweek, effectiveActiveChip, unusedChipIds, fplChipsHistory]);
 
   // Chip display metadata (label, colour, description) for the viewed GW chip.
   const viewedGwChipData = CHIPS.find(c => c.id === viewedGwChip) ?? null;

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -120,7 +120,7 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
                       <Button
                         size='small'
                         variant='text'
-                        onClick={ () => onViewTeam(entry.entry, entry.entry_name) }
+                        onClick={ () => onViewTeam(entry.entry, entry.entry_name, entry.player_name) }
                         sx={ {
                           p: 0,
                           minWidth: 0,

--- a/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
+++ b/frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx
@@ -94,6 +94,7 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
               <TableRow>
                 <TableCell>Rank</TableCell>
                 <TableCell>Team</TableCell>
+                <TableCell>Manager</TableCell>
                 <TableCell align='right'>GW Pts</TableCell>
                 <TableCell align='right'>Total</TableCell>
                 { isFuture && <TableCell align='right'>Predicted</TableCell> }
@@ -133,7 +134,9 @@ const InvitationLeagueView = ({ league, onViewTeam, currentGameweek, selectedGam
                       >
                         { entry.entry_name }
                       </Button>
-                      <Typography variant='caption' display='block' color='text.secondary'>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant='body2' color='text.secondary'>
                         { entry.player_name }
                       </Typography>
                     </TableCell>

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -196,7 +196,7 @@ const NavigationBar = ({
                 >
                   { Array.from({ length: 38 }, (_, i) => i + 1).map((gw) => (
                     <MenuItem key={ gw } value={ gw }>
-                      GW { gw }{ gw === currentGameweek ? ' (Current)' : '' }
+                      GW { gw }
                     </MenuItem>
                   )) }
                 </Select>

--- a/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
+++ b/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
@@ -36,6 +36,14 @@ import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 
 const POSITION_LABELS = { 1: 'GK', 2: 'DEF', 3: 'MID', 4: 'FWD', 5: 'MAN' };
 
+// Chip configuration — mirrors the CHIPS array in App.jsx
+const CHIPS_CONFIG = [
+  { id: 'bench_boost',    label: 'BB', name: 'Bench Boost',    color: '#2e7d32' },
+  { id: 'triple_captain', label: 'TC', name: 'Triple Captain', color: '#1565c0' },
+  { id: 'free_hit',       label: 'FH', name: 'Free Hit',       color: '#e65100' },
+  { id: 'wildcard',       label: 'WC', name: 'Wildcard',       color: '#6a1b9a' },
+];
+
 // Module-level cache: avoids re-fetching forecast data for the same set of
 // gameweeks across renders.  Keys are individual GW numbers.
 const gwDataCache = {};
@@ -319,6 +327,9 @@ const PlannedTransfers = ({
   compact = false,
   voidedTransferIds = new Set(),
   freeHitGWs = new Set(),
+  plannedChipsByGW = {},
+  unusedChipIds = [],
+  onChipToggle,
 }) => {
   const theme = useTheme();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -365,77 +376,115 @@ const PlannedTransfers = ({
           <Typography variant='body2' color='text.secondary'>No planned transfers yet.</Typography>
         ) : (
           <Box sx={ { display: 'flex', flexDirection: 'column', gap: 1 } }>
-            { sorted.map((t, idx) => {
-              const isVoided = voidedTransferIds.has(t.id);
-              const isFH = freeHitGWs.has(t.gameweek);
-              const outForecast = buildForecast(t.playerOut.code, t.gameweek);
-              const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
-              const totalDiff =
-                inForecast.reduce((s, x) => s + x.points, 0) -
-                outForecast.reduce((s, x) => s + x.points, 0);
-              return (
-                <Box key={ t.id }>
-                  { idx > 0 && <Divider sx={ { mb: 1 } } /> }
-                  { isVoided && (
-                    <Typography variant='caption' color='warning.main' sx={ { display: 'block', mb: 0.25, fontStyle: 'italic' } }>
-                      Not made – transfer was not executed in FPL
+            { (() => {
+              const gwNums = [...new Set(sorted.map(t => t.gameweek))];
+              return gwNums.flatMap((gw) => {
+                const gwTransfers = sorted.filter(t => t.gameweek === gw);
+                const chipId = plannedChipsByGW?.[gw];
+                const chipData = CHIPS_CONFIG.find(c => c.id === chipId);
+                const isFH = freeHitGWs.has(gw);
+                const availableChips = CHIPS_CONFIG.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
+                return [
+                  // GW header with chip selector
+                  <Box key={ `gw-hdr-${gw}` } sx={ { display: 'flex', alignItems: 'center', gap: 1, pt: 0.5 } }>
+                    <Typography variant='caption' fontWeight={ 700 } color='text.secondary' sx={ { minWidth: 38 } }>
+                      GW { gw }
                     </Typography>
-                  ) }
-                  { isFH && !isVoided && (
-                    <Tooltip title={ `Free Hit active — this transfer reverts after GW${t.gameweek}` }>
-                      <Chip
-                        label='Free Hit'
-                        size='small'
-                        sx={ { height: 18, fontSize: '0.6rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', mb: 0.5, cursor: 'default' } }
-                      />
-                    </Tooltip>
-                  ) }
-                  <Box
-                    sx={ {
-                      display: 'flex',
-                      alignItems: 'flex-start',
-                      gap: 0.5,
-                      flexWrap: 'wrap',
-                      opacity: isVoided ? 0.5 : 1,
-                    } }
-                  >
-                    <Box sx={ { flex: '1 1 0', minWidth: 0 } }>
-                      <Typography
-                        variant='body2'
-                        fontWeight='bold'
-                        noWrap
-                        sx={ isVoided ? { textDecoration: 'line-through' } : {} }
-                      >{ t.playerOut.name }</Typography>
-                      <PointsFixturesForecast gwData={ outForecast } pointsColor='error' />
-                    </Box>
-                    <SwapHorizIcon sx={ { fontSize: 18, color: 'text.secondary', flexShrink: 0, mt: 0.5 } } />
-                    <Box sx={ { flex: '1 1 0', minWidth: 0 } }>
-                      <Typography
-                        variant='body2'
-                        fontWeight='bold'
-                        noWrap
-                        sx={ isVoided ? { textDecoration: 'line-through' } : {} }
-                      >{ t.playerIn.name }</Typography>
-                      <PointsFixturesForecast gwData={ inForecast } pointsColor='success.main' diff={ !isVoided ? totalDiff : undefined } />
-                    </Box>
-                    <Select
-                      size='small'
-                      value={ t.gameweek }
-                      onChange={ (e) => onUpdateGameweek(t.id, e.target.value) }
-                      sx={ { fontSize: '0.7rem', height: 24, minWidth: 60 } }
-                      disabled={ isVoided }
-                    >
-                      { gwOptions.map((gw) => (
-                        <MenuItem key={ gw } value={ gw } sx={ { fontSize: '0.75rem' } }>GW { gw }</MenuItem>
-                      )) }
-                    </Select>
-                    <IconButton size='small' onClick={ () => onRemove(t.id) } sx={ { color: theme.palette.error.main, p: 0.25 } }>
-                      <DeleteIcon sx={ { fontSize: 16 } } />
-                    </IconButton>
-                  </Box>
-                </Box>
-              );
-            }) }
+                    { onChipToggle && availableChips.length > 0 && (
+                      <Box sx={ { display: 'flex', gap: 0.4 } }>
+                        { availableChips.map(c => (
+                          <Tooltip key={ c.id } title={ c.name }>
+                            <Button
+                              size='small'
+                              variant={ chipId === c.id ? 'contained' : 'outlined' }
+                              onClick={ () => onChipToggle(c.id, gw) }
+                              sx={ {
+                                minWidth: 0, px: 0.6, py: '1px', fontSize: '0.6rem', fontWeight: 700, lineHeight: 1.4,
+                                ...(chipId === c.id && { backgroundColor: c.color, borderColor: c.color, color: '#fff', '&:hover': { backgroundColor: c.color, filter: 'brightness(1.1)' } }),
+                                ...(chipId !== c.id && { borderColor: c.color, color: c.color, '&:hover': { borderColor: c.color, backgroundColor: `${c.color}18` } }),
+                              } }
+                            >{ c.label }</Button>
+                          </Tooltip>
+                        )) }
+                      </Box>
+                    ) }
+                    { chipData && !onChipToggle && (
+                      <Tooltip title={ chipData.name }>
+                        <Box component='span' sx={ { px: 0.5, py: '1px', borderRadius: '3px', backgroundColor: chipData.color, color: '#fff', fontSize: '0.6rem', fontWeight: 700, cursor: 'default' } }>
+                          { chipData.label }
+                        </Box>
+                      </Tooltip>
+                    ) }
+                    { isFH && chipId !== 'free_hit' && (
+                      <Chip label='FH' size='small' sx={ { height: 16, fontSize: '0.55rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', cursor: 'default' } } />
+                    ) }
+                  </Box>,
+                  // Transfer rows for this GW
+                  ...gwTransfers.map((t) => {
+                    const isVoided = voidedTransferIds.has(t.id);
+                    const outForecast = buildForecast(t.playerOut.code, t.gameweek);
+                    const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
+                    const totalDiff =
+                      inForecast.reduce((s, x) => s + x.points, 0) -
+                      outForecast.reduce((s, x) => s + x.points, 0);
+                    return (
+                      <Box key={ t.id } sx={ { pl: 1 } }>
+                        { isVoided && (
+                          <Typography variant='caption' color='warning.main' sx={ { display: 'block', mb: 0.25, fontStyle: 'italic' } }>
+                            Not made – transfer was not executed in FPL
+                          </Typography>
+                        ) }
+                        <Box
+                          sx={ {
+                            display: 'flex',
+                            alignItems: 'flex-start',
+                            gap: 0.5,
+                            flexWrap: 'wrap',
+                            opacity: isVoided ? 0.5 : 1,
+                          } }
+                        >
+                          <Box sx={ { flex: '1 1 0', minWidth: 0 } }>
+                            <Typography
+                              variant='body2'
+                              fontWeight='bold'
+                              noWrap
+                              sx={ isVoided ? { textDecoration: 'line-through' } : {} }
+                            >{ t.playerOut.name }</Typography>
+                            <PointsFixturesForecast gwData={ outForecast } pointsColor='error' />
+                          </Box>
+                          <SwapHorizIcon sx={ { fontSize: 18, color: 'text.secondary', flexShrink: 0, mt: 0.5 } } />
+                          <Box sx={ { flex: '1 1 0', minWidth: 0 } }>
+                            <Typography
+                              variant='body2'
+                              fontWeight='bold'
+                              noWrap
+                              sx={ isVoided ? { textDecoration: 'line-through' } : {} }
+                            >{ t.playerIn.name }</Typography>
+                            <PointsFixturesForecast gwData={ inForecast } pointsColor='success.main' diff={ !isVoided ? totalDiff : undefined } />
+                          </Box>
+                          <Select
+                            size='small'
+                            value={ t.gameweek }
+                            onChange={ (e) => onUpdateGameweek(t.id, e.target.value) }
+                            sx={ { fontSize: '0.7rem', height: 24, minWidth: 60 } }
+                            disabled={ isVoided }
+                          >
+                            { gwOptions.map((gw) => (
+                              <MenuItem key={ gw } value={ gw } sx={ { fontSize: '0.75rem' } }>GW { gw }</MenuItem>
+                            )) }
+                          </Select>
+                          <IconButton size='small' onClick={ () => onRemove(t.id) } sx={ { color: theme.palette.error.main, p: 0.25 } }>
+                            <DeleteIcon sx={ { fontSize: 16 } } />
+                          </IconButton>
+                        </Box>
+                      </Box>
+                    );
+                  }),
+                  // Divider between GW groups (not after the last one)
+                  gw !== gwNums[gwNums.length - 1] && <Divider key={ `gw-div-${gw}` } sx={ { mt: 0.5 } } />,
+                ];
+              });
+            })() }
           </Box>
         ) }
 
@@ -476,81 +525,122 @@ const PlannedTransfers = ({
         <TableContainer component={ Paper } sx={ { backgroundColor: theme.palette.mode === 'dark' ? '#1e2127' : '#ffffff' } }>
           <Table size='small'>
             <TableBody>
-              { sorted.map((t) => {
-                const isVoided = voidedTransferIds.has(t.id);
-                const isFH = freeHitGWs.has(t.gameweek);
-                const outForecast = buildForecast(t.playerOut.code, t.gameweek);
-                const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
-                const totalDiff =
-                  inForecast.reduce((s, x) => s + x.points, 0) -
-                  outForecast.reduce((s, x) => s + x.points, 0);
-                return (
-                  <TableRow
-                    key={ t.id }
-                    sx={ {
-                      '&:hover': { backgroundColor: theme.palette.action.hover },
-                      opacity: isVoided ? 0.55 : 1,
-                    } }
-                  >
-                    { /* Player Out */ }
-                    <TableCell sx={ { borderRight: `2px solid ${theme.palette.divider}`, minWidth: 150 } }>
-                      { isVoided && (
-                        <Typography variant='caption' color='warning.main' sx={ { display: 'block', fontStyle: 'italic' } }>
-                          Not made
-                        </Typography>
-                      ) }
-                      { isFH && !isVoided && (
-                        <Tooltip title={ `Free Hit active — this transfer reverts after GW${t.gameweek}` }>
-                          <Chip
-                            label='Free Hit'
-                            size='small'
-                            sx={ { height: 18, fontSize: '0.6rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', mb: 0.5, cursor: 'default' } }
-                          />
-                        </Tooltip>
-                      ) }
-                      <Typography
-                        variant='body2'
-                        fontWeight='bold'
-                        sx={ isVoided ? { textDecoration: 'line-through' } : {} }
-                      >{ t.playerOut.name }</Typography>
-                      <PointsFixturesForecast gwData={ outForecast } pointsColor='error' />
-                    </TableCell>
-                    { /* Arrow */ }
-                    <TableCell sx={ { px: 0.5, width: 24 } }>
-                      <SwapHorizIcon sx={ { fontSize: 20, color: 'text.secondary' } } />
-                    </TableCell>
-                    { /* Player In */ }
-                    <TableCell sx={ { minWidth: 150 } }>
-                      <Typography
-                        variant='body2'
-                        fontWeight='bold'
-                        sx={ isVoided ? { textDecoration: 'line-through' } : {} }
-                      >{ t.playerIn.name }</Typography>
-                      <PointsFixturesForecast gwData={ inForecast } pointsColor='success.main' diff={ !isVoided ? totalDiff : undefined } />
-                    </TableCell>
-                    { /* Gameweek selector */ }
-                    <TableCell sx={ { width: 90 } }>
-                      <Select
-                        size='small'
-                        value={ t.gameweek }
-                        onChange={ (e) => onUpdateGameweek(t.id, e.target.value) }
-                        sx={ { fontSize: '0.75rem' } }
-                        disabled={ isVoided }
-                      >
-                        { gwOptions.map((gw) => (
-                          <MenuItem key={ gw } value={ gw } sx={ { fontSize: '0.75rem' } }>GW { gw }</MenuItem>
-                        )) }
-                      </Select>
-                    </TableCell>
-                    { /* Delete */ }
-                    <TableCell sx={ { width: 40 } }>
-                      <IconButton size='small' onClick={ () => onRemove(t.id) } sx={ { color: theme.palette.error.main } }>
-                        <DeleteIcon fontSize='small' />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
-                );
-              }) }
+              { (() => {
+                const gwNums = [...new Set(sorted.map(t => t.gameweek))];
+                return gwNums.flatMap((gw) => {
+                  const gwTransfers = sorted.filter(t => t.gameweek === gw);
+                  const chipId = plannedChipsByGW?.[gw];
+                  const chipData = CHIPS_CONFIG.find(c => c.id === chipId);
+                  const isFH = freeHitGWs.has(gw);
+                  const availableChips = CHIPS_CONFIG.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
+                  return [
+                    // GW header row with chip selector
+                    <TableRow key={ `gw-hdr-${gw}` } sx={ { backgroundColor: theme.palette.action.hover } }>
+                      <TableCell colSpan={ 5 } sx={ { py: 0.75, borderBottom: `2px solid ${theme.palette.divider}` } }>
+                        <Box sx={ { display: 'flex', alignItems: 'center', gap: 1 } }>
+                          <Typography variant='caption' fontWeight={ 700 } sx={ { minWidth: 40 } }>
+                            GW { gw }
+                          </Typography>
+                          { onChipToggle && availableChips.length > 0 && (
+                            <Box sx={ { display: 'flex', gap: 0.4 } }>
+                              { availableChips.map(c => (
+                                <Tooltip key={ c.id } title={ c.name }>
+                                  <Button
+                                    size='small'
+                                    variant={ chipId === c.id ? 'contained' : 'outlined' }
+                                    onClick={ () => onChipToggle(c.id, gw) }
+                                    sx={ {
+                                      minWidth: 0, px: 0.75, py: '1px', fontSize: '0.6rem', fontWeight: 700, lineHeight: 1.4,
+                                      ...(chipId === c.id && { backgroundColor: c.color, borderColor: c.color, color: '#fff', '&:hover': { backgroundColor: c.color, filter: 'brightness(1.1)' } }),
+                                      ...(chipId !== c.id && { borderColor: c.color, color: c.color, '&:hover': { borderColor: c.color, backgroundColor: `${c.color}18` } }),
+                                    } }
+                                  >{ c.label }</Button>
+                                </Tooltip>
+                              )) }
+                            </Box>
+                          ) }
+                          { chipData && !onChipToggle && (
+                            <Tooltip title={ chipData.name }>
+                              <Box component='span' sx={ { px: 0.6, py: '1px', borderRadius: '3px', backgroundColor: chipData.color, color: '#fff', fontSize: '0.6rem', fontWeight: 700, cursor: 'default' } }>
+                                { chipData.label }
+                              </Box>
+                            </Tooltip>
+                          ) }
+                          { isFH && chipId !== 'free_hit' && (
+                            <Chip label='FH active' size='small' sx={ { height: 16, fontSize: '0.55rem', fontWeight: 700, bgcolor: '#e65100', color: '#fff', cursor: 'default' } } />
+                          ) }
+                        </Box>
+                      </TableCell>
+                    </TableRow>,
+                    // Transfer rows for this GW
+                    ...gwTransfers.map((t) => {
+                      const isVoided = voidedTransferIds.has(t.id);
+                      const outForecast = buildForecast(t.playerOut.code, t.gameweek);
+                      const inForecast  = buildForecast(t.playerIn.code,  t.gameweek);
+                      const totalDiff =
+                        inForecast.reduce((s, x) => s + x.points, 0) -
+                        outForecast.reduce((s, x) => s + x.points, 0);
+                      return (
+                        <TableRow
+                          key={ t.id }
+                          sx={ {
+                            '&:hover': { backgroundColor: theme.palette.action.hover },
+                            opacity: isVoided ? 0.55 : 1,
+                          } }
+                        >
+                          { /* Player Out */ }
+                          <TableCell sx={ { borderRight: `2px solid ${theme.palette.divider}`, minWidth: 150 } }>
+                            { isVoided && (
+                              <Typography variant='caption' color='warning.main' sx={ { display: 'block', fontStyle: 'italic' } }>
+                                Not made
+                              </Typography>
+                            ) }
+                            <Typography
+                              variant='body2'
+                              fontWeight='bold'
+                              sx={ isVoided ? { textDecoration: 'line-through' } : {} }
+                            >{ t.playerOut.name }</Typography>
+                            <PointsFixturesForecast gwData={ outForecast } pointsColor='error' />
+                          </TableCell>
+                          { /* Arrow */ }
+                          <TableCell sx={ { px: 0.5, width: 24 } }>
+                            <SwapHorizIcon sx={ { fontSize: 20, color: 'text.secondary' } } />
+                          </TableCell>
+                          { /* Player In */ }
+                          <TableCell sx={ { minWidth: 150 } }>
+                            <Typography
+                              variant='body2'
+                              fontWeight='bold'
+                              sx={ isVoided ? { textDecoration: 'line-through' } : {} }
+                            >{ t.playerIn.name }</Typography>
+                            <PointsFixturesForecast gwData={ inForecast } pointsColor='success.main' diff={ !isVoided ? totalDiff : undefined } />
+                          </TableCell>
+                          { /* Gameweek selector */ }
+                          <TableCell sx={ { width: 90 } }>
+                            <Select
+                              size='small'
+                              value={ t.gameweek }
+                              onChange={ (e) => onUpdateGameweek(t.id, e.target.value) }
+                              sx={ { fontSize: '0.75rem' } }
+                              disabled={ isVoided }
+                            >
+                              { gwOptions.map((gw) => (
+                                <MenuItem key={ gw } value={ gw } sx={ { fontSize: '0.75rem' } }>GW { gw }</MenuItem>
+                              )) }
+                            </Select>
+                          </TableCell>
+                          { /* Delete */ }
+                          <TableCell sx={ { width: 40 } }>
+                            <IconButton size='small' onClick={ () => onRemove(t.id) } sx={ { color: theme.palette.error.main } }>
+                              <DeleteIcon fontSize='small' />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    }),
+                  ];
+                });
+              })() }
             </TableBody>
           </Table>
         </TableContainer>
@@ -580,6 +670,9 @@ PlannedTransfers.propTypes = {
   compact: PropTypes.bool,
   voidedTransferIds: PropTypes.instanceOf(Set),
   freeHitGWs: PropTypes.instanceOf(Set),
+  plannedChipsByGW: PropTypes.object,
+  unusedChipIds: PropTypes.arrayOf(PropTypes.string),
+  onChipToggle: PropTypes.func,
 };
 
 export default PlannedTransfers;

--- a/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
+++ b/frontend/src/components/PlannedTransfers/PlannedTransfers.jsx
@@ -34,15 +34,9 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 
-const POSITION_LABELS = { 1: 'GK', 2: 'DEF', 3: 'MID', 4: 'FWD', 5: 'MAN' };
+import { CHIPS } from '../../constants/chips';
 
-// Chip configuration — mirrors the CHIPS array in App.jsx
-const CHIPS_CONFIG = [
-  { id: 'bench_boost',    label: 'BB', name: 'Bench Boost',    color: '#2e7d32' },
-  { id: 'triple_captain', label: 'TC', name: 'Triple Captain', color: '#1565c0' },
-  { id: 'free_hit',       label: 'FH', name: 'Free Hit',       color: '#e65100' },
-  { id: 'wildcard',       label: 'WC', name: 'Wildcard',       color: '#6a1b9a' },
-];
+const POSITION_LABELS = { 1: 'GK', 2: 'DEF', 3: 'MID', 4: 'FWD', 5: 'MAN' };
 
 // Module-level cache: avoids re-fetching forecast data for the same set of
 // gameweeks across renders.  Keys are individual GW numbers.
@@ -381,16 +375,16 @@ const PlannedTransfers = ({
               return gwNums.flatMap((gw) => {
                 const gwTransfers = sorted.filter(t => t.gameweek === gw);
                 const chipId = plannedChipsByGW?.[gw];
-                const chipData = CHIPS_CONFIG.find(c => c.id === chipId);
+                const chipData = CHIPS.find(c => c.id === chipId);
                 const isFH = freeHitGWs.has(gw);
-                const availableChips = CHIPS_CONFIG.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
+                const availableChips = CHIPS.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
                 return [
                   // GW header with chip selector
                   <Box key={ `gw-hdr-${gw}` } sx={ { display: 'flex', alignItems: 'center', gap: 1, pt: 0.5 } }>
                     <Typography variant='caption' fontWeight={ 700 } color='text.secondary' sx={ { minWidth: 38 } }>
                       GW { gw }
                     </Typography>
-                    { onChipToggle && availableChips.length > 0 && (
+                    { onChipToggle && gw > currentGameweek && availableChips.length > 0 && (
                       <Box sx={ { display: 'flex', gap: 0.4 } }>
                         { availableChips.map(c => (
                           <Tooltip key={ c.id } title={ c.name }>
@@ -530,9 +524,9 @@ const PlannedTransfers = ({
                 return gwNums.flatMap((gw) => {
                   const gwTransfers = sorted.filter(t => t.gameweek === gw);
                   const chipId = plannedChipsByGW?.[gw];
-                  const chipData = CHIPS_CONFIG.find(c => c.id === chipId);
+                  const chipData = CHIPS.find(c => c.id === chipId);
                   const isFH = freeHitGWs.has(gw);
-                  const availableChips = CHIPS_CONFIG.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
+                  const availableChips = CHIPS.filter(c => unusedChipIds.includes(c.id) || chipId === c.id);
                   return [
                     // GW header row with chip selector
                     <TableRow key={ `gw-hdr-${gw}` } sx={ { backgroundColor: theme.palette.action.hover } }>
@@ -541,7 +535,7 @@ const PlannedTransfers = ({
                           <Typography variant='caption' fontWeight={ 700 } sx={ { minWidth: 40 } }>
                             GW { gw }
                           </Typography>
-                          { onChipToggle && availableChips.length > 0 && (
+                          { onChipToggle && gw > currentGameweek && availableChips.length > 0 && (
                             <Box sx={ { display: 'flex', gap: 0.4 } }>
                               { availableChips.map(c => (
                                 <Tooltip key={ c.id } title={ c.name }>

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -7,6 +7,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import RemoveIcon from '@mui/icons-material/Remove';
 import axios from '../../api';
 import AssistantManagerPanel from '../AssistantManagerPanel';
+import { FPL_CHIP_LABEL, FPL_CHIP_COLOR } from '../../constants/chips';
 
 const TeamActivityPanel = ({
   entryId,
@@ -205,8 +206,6 @@ const TeamActivityPanel = ({
                   Recent Form
                 </Typography>
                 { (() => {
-                  const CHIP_LABEL = { bboost: 'BB', '3xc': 'TC', freehit: 'FH', wildcard: 'WC' };
-                  const CHIP_COLOR = { bboost: '#2e7d32', '3xc': '#1565c0', freehit: '#e65100', wildcard: '#6a1b9a' };
                   return (
                     <Box sx={ { display: 'flex', gap: 0.75 } }>
                       { recentHistory.map((gw) => {
@@ -220,8 +219,8 @@ const TeamActivityPanel = ({
                               : theme.palette.text.secondary;
                         }
                         const gwChip = profile?.chips?.find(c => c.event === gw.event);
-                        const chipLabel = gwChip ? CHIP_LABEL[gwChip.name] : null;
-                        const chipColor = gwChip ? CHIP_COLOR[gwChip.name] : null;
+                        const chipLabel = gwChip ? FPL_CHIP_LABEL[gwChip.name] : null;
+                        const chipColor = gwChip ? FPL_CHIP_COLOR[gwChip.name] : null;
                         return (
                           <Box
                             key={ gw.event }

--- a/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
+++ b/frontend/src/components/TeamActivityPanel/TeamActivityPanel.jsx
@@ -204,50 +204,75 @@ const TeamActivityPanel = ({
                 <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 } }>
                   Recent Form
                 </Typography>
-                <Box sx={ { display: 'flex', gap: 0.75 } }>
-                  { recentHistory.map((gw) => {
-                    const prevGw = history.find(h => h.event === gw.event - 1);
-                    // Lower rank number = better. Green if rank improved (fell), red if worsened (rose).
-                    let rankColor = theme.palette.text.secondary;
-                    if (prevGw?.overall_rank != null && gw.overall_rank != null) {
-                      rankColor = gw.overall_rank < prevGw.overall_rank
-                        ? theme.palette.success.main
-                        : gw.overall_rank > prevGw.overall_rank
-                          ? theme.palette.error.main
-                          : theme.palette.text.secondary;
-                    }
-                    return (
-                    <Box
-                      key={ gw.event }
-                      sx={ {
-                        flex: 1,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        gap: 0.25,
-                        py: 0.5,
-                        px: 0.25,
-                        borderRadius: 1,
-                        backgroundColor: theme.palette.action.hover,
-                      } }
-                    >
-                      <Typography variant='caption' color='text.secondary' sx={ { fontSize: '0.6rem', lineHeight: 1 } }>
-                        GW{ gw.event }
-                      </Typography>
-                      <Typography
-                        variant='body2'
-                        fontWeight='700'
-                        sx={ { lineHeight: 1, color: rankColor } }
-                      >
-                        { gw.points }
-                      </Typography>
-                      <Typography variant='caption' sx={ { fontSize: '0.6rem', lineHeight: 1, color: rankColor } }>
-                        { formatRank(gw.overall_rank) }
-                      </Typography>
+                { (() => {
+                  const CHIP_LABEL = { bboost: 'BB', '3xc': 'TC', freehit: 'FH', wildcard: 'WC' };
+                  const CHIP_COLOR = { bboost: '#2e7d32', '3xc': '#1565c0', freehit: '#e65100', wildcard: '#6a1b9a' };
+                  return (
+                    <Box sx={ { display: 'flex', gap: 0.75 } }>
+                      { recentHistory.map((gw) => {
+                        const prevGw = history.find(h => h.event === gw.event - 1);
+                        let rankColor = theme.palette.text.secondary;
+                        if (prevGw?.overall_rank != null && gw.overall_rank != null) {
+                          rankColor = gw.overall_rank < prevGw.overall_rank
+                            ? theme.palette.success.main
+                            : gw.overall_rank > prevGw.overall_rank
+                              ? theme.palette.error.main
+                              : theme.palette.text.secondary;
+                        }
+                        const gwChip = profile?.chips?.find(c => c.event === gw.event);
+                        const chipLabel = gwChip ? CHIP_LABEL[gwChip.name] : null;
+                        const chipColor = gwChip ? CHIP_COLOR[gwChip.name] : null;
+                        return (
+                          <Box
+                            key={ gw.event }
+                            sx={ {
+                              flex: 1,
+                              display: 'flex',
+                              flexDirection: 'column',
+                              alignItems: 'center',
+                              gap: 0.25,
+                              py: 0.5,
+                              px: 0.25,
+                              borderRadius: 1,
+                              backgroundColor: theme.palette.action.hover,
+                            } }
+                          >
+                            <Typography variant='caption' color='text.secondary' sx={ { fontSize: '0.6rem', lineHeight: 1 } }>
+                              GW{ gw.event }
+                            </Typography>
+                            <Typography
+                              variant='body2'
+                              fontWeight='700'
+                              sx={ { lineHeight: 1, color: rankColor } }
+                            >
+                              { gw.points }
+                            </Typography>
+                            <Typography variant='caption' sx={ { fontSize: '0.6rem', lineHeight: 1, color: rankColor } }>
+                              { formatRank(gw.overall_rank) }
+                            </Typography>
+                            { chipLabel && (
+                              <Box
+                                component='span'
+                                sx={ {
+                                  px: 0.4, py: '1px',
+                                  borderRadius: '3px',
+                                  backgroundColor: chipColor,
+                                  color: '#fff',
+                                  fontSize: '0.55rem',
+                                  fontWeight: 700,
+                                  lineHeight: 1.4,
+                                  cursor: 'default',
+                                } }
+                              >
+                                { chipLabel }
+                              </Box>
+                            ) }
+                          </Box>
+                        );
+                      }) }
                     </Box>
-                    );
-                  }) }
-                </Box>
+                  );
+                })() }
               </>
             ) }
           </Box>

--- a/frontend/src/constants/chips.js
+++ b/frontend/src/constants/chips.js
@@ -1,0 +1,25 @@
+/**
+ * Canonical chip configuration shared across the application.
+ *
+ * Each entry contains both the internal chip ID used by this app and the
+ * `fplName` used by the FPL API, so that a single source of truth drives
+ * every chip-related display and mapping throughout the codebase.
+ */
+export const CHIPS = [
+  { id: 'bench_boost',    fplName: 'bboost',   label: 'BB', name: 'Bench Boost',    description: 'Bench points are added to your total',            color: '#2e7d32' },
+  { id: 'triple_captain', fplName: '3xc',      label: 'TC', name: 'Triple Captain', description: '3× captain multiplier instead of 2×',             color: '#1565c0' },
+  { id: 'free_hit',       fplName: 'freehit',  label: 'FH', name: 'Free Hit',       description: 'Unlimited free transfers — reverts next week',    color: '#e65100' },
+  { id: 'wildcard',       fplName: 'wildcard', label: 'WC', name: 'Wildcard',       description: 'All transfers are free and permanent',            color: '#6a1b9a' },
+];
+
+/** Internal chip ID → FPL API chip name  (e.g. 'bench_boost' → 'bboost') */
+export const CHIP_ID_TO_FPL = Object.fromEntries(CHIPS.map(c => [c.id, c.fplName]));
+
+/** FPL API chip name → internal chip ID  (e.g. 'bboost' → 'bench_boost') */
+export const FPL_TO_CHIP_ID = Object.fromEntries(CHIPS.map(c => [c.fplName, c.id]));
+
+/** FPL API chip name → short badge label (e.g. 'bboost' → 'BB') */
+export const FPL_CHIP_LABEL = Object.fromEntries(CHIPS.map(c => [c.fplName, c.label]));
+
+/** FPL API chip name → display colour    (e.g. 'bboost' → '#2e7d32') */
+export const FPL_CHIP_COLOR = Object.fromEntries(CHIPS.map(c => [c.fplName, c.color]));


### PR DESCRIPTION
This pull request introduces significant improvements to the Fantasy Football frontend, focusing on enhanced chip management, improved opponent viewing experience, and UI/UX refinements. The changes enable more accurate chip tracking (both planned and played), provide richer context when viewing opponent teams, and add visual cues for chip usage. Several props and state variables are added or refactored to support these features across components.

**Chip Management Enhancements:**
* Added full chip history tracking (`fplChipsHistory`) for both the user and opponents, enabling accurate display of chip usage per gameweek, including for locked/past GWs and when viewing opponents. The code now maps between internal chip IDs and FPL API chip names in both directions. (`frontend/src/App.jsx` [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R160-R184) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R251-R270)
* Introduced new logic to determine the chip in effect for the currently viewed gameweek (`viewedGwChip` and `viewedGwChipData`), ensuring correct badge display and point calculation for both own and opponent teams. (`frontend/src/App.jsx` [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R251-R270) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L454-R519) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R826-R846)
* Added a callback and state to allow planning chips for any future gameweek directly from the Planned Transfers panel, not just the currently viewed GW. (`frontend/src/App.jsx` [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R93-R127) [[2]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R330-R332) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R960-R962)
* Synced chip display and point calculations to always reflect the correct chip in effect, whether planned or already played. (`frontend/src/App.jsx` [frontend/src/App.jsxL454-R519](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L454-R519))

**Opponent Viewing Improvements:**
* Enhanced the opponent viewing banner to display the opponent’s team name and manager name, with improved styling and a clearer "My Team" return button using an icon. (`frontend/src/App.jsx` [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L627-R732) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L540-R618) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R55-R56)
* Updated the league view to include a separate "Manager" column and pass both team and player names to the view handler, ensuring accurate context when switching views. (`frontend/src/components/InvitationLeagueView/InvitationLeagueView.jsx` [[1]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fR97) [[2]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL122-R123) [[3]](diffhunk://#diff-7bfc1940c9ce6e54af6fc89a20645c42f3107a14c6cc4a14f10199e16280400fL136-R139)

**UI/UX Refinements:**
* Added a chip badge (with tooltip) next to the points display, showing which chip (if any) is in effect for the viewed team and gameweek, including for opponents. (`frontend/src/App.jsx` [frontend/src/App.jsxR826-R846](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R826-R846))
* Improved the Planned Transfers panel to support chip planning for any future GW and display unused chips, aligning with the new chip management logic. (`frontend/src/components/PlannedTransfers/PlannedTransfers.jsx` [[1]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R39-R46) [[2]](diffhunk://#diff-fa8134ce43d711af4cb8c537a8d2ef95a061b8bddc7a05bb8a27e2b523788471R330-R332) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R960-R962)
* Minor: Removed redundant "(Current)" label from the gameweek selector for a cleaner navigation bar. (`frontend/src/components/NavigationBar/NavigationBar.jsx` [frontend/src/components/NavigationBar/NavigationBar.jsxL199-R199](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134L199-R199))

These updates collectively make chip usage more transparent and interactive, while enhancing the clarity and polish of the team and league views.