### PR TITLE
Add entry transfers API and integrate with frontend for display

### DIFF
--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -1346,7 +1346,11 @@ const getPlayersForecast = async (req, res) => {
  * transfers if no gameweek is supplied).  Player names are resolved from
  * bootstrap-static so the frontend never needs to look them up separately.
  *
- * Response shape: Array of { playerIn, playerOut, event, time }
+ * Response shape:
+ * {
+ *   transfers: Array<{ playerIn, playerOut, event, time }>,
+ *   meta: { eventTransfers, transferCost } | null
+ * }
  * where playerIn/Out = { id, name, webName, cost }
  */
 const getEntryTransfers = async (req, res) => {

--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -729,13 +729,22 @@ const getAllPlayersEnriched = async (req, res) => {
       ...p,
       ep_next: parseFloat(p.ep_next) || 0,
     }));
+
+    // For past or active gameweeks, enrich with actual points from the live endpoint
+    // so that event_points reflects the correct GW score for every player.
+    const targetEventData = data.events.find(e => e.id === targetEvent);
+    const isPastOrActive = !!(targetEventData && (targetEventData.finished || targetEventData.is_current));
+    if (isPastOrActive) {
+      players = await fplModel.enrichPlayersWithGameweekStats(players, targetEvent);
+    }
     
     // Enrich players with opponent display data for the target gameweek
     players = fplModel.enrichPlayersWithOpponents(players, fixtures, data.teams, targetEvent);
     
-    // Apply the advanced prediction engine for the target gameweek so that
-    // blank-GW teams correctly receive 0 predicted points in the transfer UI.
-    players = fplModel.applyAdvancedPredictions(players, fixtures, data.teams, targetEvent);
+    // Apply the advanced prediction engine for future gameweeks only.
+    if (!isPastOrActive) {
+      players = fplModel.applyAdvancedPredictions(players, fixtures, data.teams, targetEvent);
+    }
 
     // Add a pre-formatted opponent display string so the frontend does not need
     // to duplicate the formatting logic for single vs DGW fixtures.
@@ -1330,6 +1339,90 @@ const getPlayersForecast = async (req, res) => {
   }
 };
 
+/**
+ * GET /api/entry/:entryId/transfers?gameweek=N
+ *
+ * Returns the FPL transfers made by an entry for the given gameweek (or all
+ * transfers if no gameweek is supplied).  Player names are resolved from
+ * bootstrap-static so the frontend never needs to look them up separately.
+ *
+ * Response shape: Array of { playerIn, playerOut, event, time }
+ * where playerIn/Out = { id, name, webName, cost }
+ */
+const getEntryTransfers = async (req, res) => {
+  const { entryId } = req.params;
+  const { gameweek } = req.query;
+
+  if (!/^\d+$/.test(entryId)) {
+    return res.status(400).json({ error: 'Invalid entryId' });
+  }
+
+  let filterGW;
+  if (gameweek !== undefined) {
+    if (!/^\d+$/.test(gameweek)) {
+      return res.status(400).json({ error: 'Invalid gameweek' });
+    }
+    filterGW = parseInt(gameweek, 10);
+    if (filterGW < 1 || filterGW > 38) {
+      return res.status(400).json({ error: 'Gameweek must be between 1 and 38' });
+    }
+  }
+
+  try {
+    const fetches = [
+      fplModel.fetchBootstrapStatic(),
+      dataProvider.fetchEntryTransfers(entryId),
+    ];
+    // Fetch picks for the specific GW so we can surface the transfer cost
+    if (filterGW !== undefined) {
+      fetches.push(dataProvider.fetchPlayerPicks(entryId, filterGW).catch(() => null));
+    }
+    const [bootstrap, allTransfers, picksData] = await Promise.all(fetches);
+
+    const playerMap = {};
+    for (const p of bootstrap.elements) {
+      playerMap[p.id] = p;
+    }
+
+    const filtered = filterGW !== undefined
+      ? allTransfers.filter(t => t.event === filterGW)
+      : allTransfers;
+
+    const transfers = filtered.map(t => {
+      const pIn  = playerMap[t.element_in];
+      const pOut = playerMap[t.element_out];
+      return {
+        event: t.event,
+        time: t.time,
+        playerIn: {
+          id: t.element_in,
+          name: pIn  ? `${pIn.first_name} ${pIn.second_name}`   : 'Unknown',
+          webName: pIn  ? pIn.web_name  : 'Unknown',
+          cost: t.element_in_cost,
+        },
+        playerOut: {
+          id: t.element_out,
+          name: pOut ? `${pOut.first_name} ${pOut.second_name}` : 'Unknown',
+          webName: pOut ? pOut.web_name : 'Unknown',
+          cost: t.element_out_cost,
+        },
+      };
+    });
+
+    // Include transfer cost metadata from picks entry_history when available
+    const entryHistory = picksData?.entry_history ?? null;
+    const meta = entryHistory ? {
+      eventTransfers: entryHistory.event_transfers ?? transfers.length,
+      transferCost: entryHistory.event_transfers_cost ?? 0,
+    } : null;
+
+    res.json({ transfers, meta });
+  } catch (error) {
+    console.error('Error fetching entry transfers:', error.message);
+    res.status(500).json({ error: 'Error fetching entry transfers' });
+  }
+};
+
 module.exports = {
   getBootstrapStatic,
   getFixtures,
@@ -1346,4 +1439,5 @@ module.exports = {
   getRecommendedTransfers,
   getLeagueStandings,
   getPlayersForecast,
+  getEntryTransfers,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -29,6 +29,7 @@ app.get('/api/entry/:entryId/event/:eventId/team', apiLimiter, fplController.get
 app.get('/api/entry/:entryId/profile', apiLimiter, fplController.getUserProfile);
 app.get('/api/leagues-classic/:leagueId/standings', apiLimiter, fplController.getLeagueStandings);
 app.get('/api/entry/:entryId/event/:eventId/recommended-transfers', apiLimiter, fplController.getRecommendedTransfers);
+app.get('/api/entry/:entryId/transfers', apiLimiter, fplController.getEntryTransfers);
 app.post('/api/validate-swap', apiLimiter, fplController.validateSwap);
 app.post('/api/available-transfers/:playerCode', apiLimiter, fplController.getAvailableTransfers);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -95,26 +95,28 @@ const App = () => {
   const gwTransfersGW = showGWTransfers ? (gameweekInfo?.selected ?? currentGameweek) : null;
   const { transfers: gwTransfers, meta: gwTransfersMeta, loading: gwTransfersLoading } = useGWTransfers(gwTransfersEntryId, gwTransfersGW);
   const [gwTransfersExpanded, setGwTransfersExpanded] = useState(false);
-  const hasGwTransfers = gwTransfers.length > 0;
+  const hasTransfersToDisplay = gwTransfers.length > 0;
 
   // Aggregate in/out/net points across all GW transfers (uses allPlayers for basePoints)
   const gwTransferPoints = useMemo(() => {
     if (!gwTransfers.length || !allPlayers.length) return null;
     const pMap = {};
     allPlayers.forEach(p => { pMap[p.id] = p; });
-    let inTotal = 0, outTotal = 0;
+    let totalIncomingPoints = 0;
+    let totalOutgoingPoints = 0;
     for (const t of gwTransfers) {
       const pIn  = pMap[t.playerIn.id];
       const pOut = pMap[t.playerOut.id];
       const inRaw = pIn ? (pIn.basePoints ?? pIn.predictedPoints ?? pIn.event_points) : null;
       const outRaw = pOut ? (pOut.basePoints ?? pOut.predictedPoints ?? pOut.event_points) : null;
+      // Mirror GWTransfersPanel: hide aggregate net unless every transfer has resolvable points.
       if (inRaw == null || outRaw == null) return null;
       const inPts = Math.round(inRaw);
       const outPts = Math.round(outRaw);
-      inTotal  += inPts;
-      outTotal += outPts;
+      totalIncomingPoints += inPts;
+      totalOutgoingPoints += outPts;
     }
-    return { in: inTotal, out: outTotal, net: inTotal - outTotal };
+    return { in: totalIncomingPoints, out: totalOutgoingPoints, net: totalIncomingPoints - totalOutgoingPoints };
   }, [gwTransfers, allPlayers]);
 
   const handleChipToggle = (chipId) => {
@@ -827,7 +829,7 @@ const App = () => {
                     </Typography>
                   ) }
                   { showGWTransfers && (
-                    hasGwTransfers ? (
+                    hasTransfersToDisplay ? (
                       <ButtonBase
                         onClick={ () => setGwTransfersExpanded(e => !e) }
                         aria-expanded={ gwTransfersExpanded }
@@ -936,7 +938,7 @@ const App = () => {
                     </Box>
                   ) }
                   { showGWTransfers && (
-                    hasGwTransfers ? (
+                    hasTransfersToDisplay ? (
                       <ButtonBase
                         onClick={ () => setGwTransfersExpanded(e => !e) }
                         aria-expanded={ gwTransfersExpanded }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
 import Typography from '@mui/material/Typography';
 import Snackbar from '@mui/material/Snackbar';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -94,23 +95,26 @@ const App = () => {
   const gwTransfersGW = showGWTransfers ? (gameweekInfo?.selected ?? currentGameweek) : null;
   const { transfers: gwTransfers, meta: gwTransfersMeta, loading: gwTransfersLoading } = useGWTransfers(gwTransfersEntryId, gwTransfersGW);
   const [gwTransfersExpanded, setGwTransfersExpanded] = useState(false);
+  const hasGwTransfers = gwTransfers.length > 0;
 
   // Aggregate in/out/net points across all GW transfers (uses allPlayers for basePoints)
   const gwTransferPoints = useMemo(() => {
     if (!gwTransfers.length || !allPlayers.length) return null;
     const pMap = {};
     allPlayers.forEach(p => { pMap[p.id] = p; });
-    let inTotal = 0, outTotal = 0, resolved = true;
+    let inTotal = 0, outTotal = 0;
     for (const t of gwTransfers) {
       const pIn  = pMap[t.playerIn.id];
       const pOut = pMap[t.playerOut.id];
-      const inPts  = pIn  ? Math.round(pIn.basePoints  ?? pIn.predictedPoints  ?? pIn.event_points  ?? 0) : null;
-      const outPts = pOut ? Math.round(pOut.basePoints ?? pOut.predictedPoints ?? pOut.event_points ?? 0) : null;
-      if (inPts == null || outPts == null) { resolved = false; break; }
+      const inRaw = pIn ? (pIn.basePoints ?? pIn.predictedPoints ?? pIn.event_points) : null;
+      const outRaw = pOut ? (pOut.basePoints ?? pOut.predictedPoints ?? pOut.event_points) : null;
+      if (inRaw == null || outRaw == null) return null;
+      const inPts = Math.round(inRaw);
+      const outPts = Math.round(outRaw);
       inTotal  += inPts;
       outTotal += outPts;
     }
-    return resolved ? { in: inTotal, out: outTotal, net: inTotal - outTotal } : null;
+    return { in: inTotal, out: outTotal, net: inTotal - outTotal };
   }, [gwTransfers, allPlayers]);
 
   const handleChipToggle = (chipId) => {
@@ -823,18 +827,29 @@ const App = () => {
                     </Typography>
                   ) }
                   { showGWTransfers && (
-                    <Box
-                      onClick={ gwTransfers.length > 0 ? () => setGwTransfersExpanded(e => !e) : undefined }
-                      sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 0.25, cursor: gwTransfers.length > 0 ? 'pointer' : 'default', userSelect: 'none' } }
-                    >
-                      <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
-                        Transfers Made
-                      </Typography>
-                      { gwTransfers.length > 0 && (gwTransfersExpanded
-                        ? <ExpandLessIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
-                        : <ExpandMoreIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
-                      ) }
-                    </Box>
+                    hasGwTransfers ? (
+                      <ButtonBase
+                        onClick={ () => setGwTransfersExpanded(e => !e) }
+                        aria-expanded={ gwTransfersExpanded }
+                        aria-controls='gw-transfers-panel'
+                        aria-label='Toggle transfers made details'
+                        sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 0.25, userSelect: 'none', borderRadius: 0.5 } }
+                      >
+                        <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
+                          Transfers Made
+                        </Typography>
+                        { gwTransfersExpanded
+                          ? <ExpandLessIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
+                          : <ExpandMoreIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
+                        }
+                      </ButtonBase>
+                    ) : (
+                      <Box sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 0.25, userSelect: 'none' } }>
+                        <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
+                          Transfers Made
+                        </Typography>
+                      </Box>
+                    )
                   ) }
                   <Box sx={ { display: 'flex', justifyContent: 'center' } }>
                     { !isHighestPredictedTeam && !viewingOpponentId && !isLockedGameweek && activePlayers.length > 0 ? (
@@ -921,20 +936,32 @@ const App = () => {
                     </Box>
                   ) }
                   { showGWTransfers && (
-                    <Box
-                      onClick={ gwTransfers.length > 0 ? () => setGwTransfersExpanded(e => !e) : undefined }
-                      sx={ { display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', cursor: gwTransfers.length > 0 ? 'pointer' : 'default', userSelect: 'none' } }
-                    >
-                      { gwTransfersLoading
-                        ? <CircularProgress size={ 16 } />
-                        : <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>{ gwTransfers.length }</Typography>
-                      }
-                      { gwTransferPoints != null && (
-                        <Typography variant='caption' sx={ { fontWeight: 700, lineHeight: 1, fontSize: '0.65rem', color: gwTransferPoints.net > 0 ? 'success.main' : gwTransferPoints.net < 0 ? 'error.main' : 'text.secondary' } }>
-                          { gwTransferPoints.net > 0 ? `+${gwTransferPoints.net}` : gwTransferPoints.net }pts
-                        </Typography>
-                      ) }
-                    </Box>
+                    hasGwTransfers ? (
+                      <ButtonBase
+                        onClick={ () => setGwTransfersExpanded(e => !e) }
+                        aria-expanded={ gwTransfersExpanded }
+                        aria-controls='gw-transfers-panel'
+                        aria-label='Toggle transfer impact details'
+                        sx={ { display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', userSelect: 'none', borderRadius: 0.5 } }
+                      >
+                        { gwTransfersLoading
+                          ? <CircularProgress size={ 16 } />
+                          : <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>{ gwTransfers.length }</Typography>
+                        }
+                        { gwTransferPoints != null && (
+                          <Typography variant='caption' sx={ { fontWeight: 700, lineHeight: 1, fontSize: '0.65rem', color: gwTransferPoints.net > 0 ? 'success.main' : gwTransferPoints.net < 0 ? 'error.main' : 'text.secondary' } }>
+                            { gwTransferPoints.net > 0 ? `+${gwTransferPoints.net}` : gwTransferPoints.net }pts
+                          </Typography>
+                        ) }
+                      </ButtonBase>
+                    ) : (
+                      <Box sx={ { display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', userSelect: 'none' } }>
+                        { gwTransfersLoading
+                          ? <CircularProgress size={ 16 } />
+                          : <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>{ gwTransfers.length }</Typography>
+                        }
+                      </Box>
+                    )
                   ) }
                   <Box sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center' } }>
                     <ToggleButtonGroup
@@ -954,7 +981,7 @@ const App = () => {
                   </Box>
                   { /* Row 3 — GW transfers collapse (spans all columns) */ }
                   { showGWTransfers && gwTransfers.length > 0 && (
-                    <Box sx={ { gridColumn: '1 / -1', textAlign: 'left' } }>
+                    <Box id='gw-transfers-panel' sx={ { gridColumn: '1 / -1', textAlign: 'left' } }>
                       <GWTransfersPanel
                         expanded={ gwTransfersExpanded }
                         transfers={ gwTransfers }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,9 @@ import GridViewIcon from '@mui/icons-material/GridView';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import CircularProgress from '@mui/material/CircularProgress';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Tooltip from '@mui/material/Tooltip';
 import TeamFormation from './components/TeamFormation/TeamFormation';
@@ -32,6 +35,7 @@ import RecommendedTransfers from './components/RecommendedTransfers';
 import TeamActivityPanel from './components/TeamActivityPanel';
 import PlannedTransfers from './components/PlannedTransfers';
 import SectionBar from './components/SectionBar';
+import GWTransfersPanel, { useGWTransfers } from './components/GWTransfers/GWTransfers';
 
 const TEAM_VIEW = {
   USER: 'user',
@@ -83,6 +87,31 @@ const App = () => {
   );
 
   const { allPlayers } = useAllPlayers(selectedGameweek);
+
+  // GW Transfers — shown in active/overview sections for non-future user/opponent views
+  const showGWTransfers = !isHighestPredictedTeam && !gameweekInfo?.isFuture && (activeSection === 'active' || activeSection === 'overview') && !!(viewingOpponentId || currentEntryId) && !!currentGameweek;
+  const gwTransfersEntryId = showGWTransfers ? (viewingOpponentId || currentEntryId) : null;
+  const gwTransfersGW = showGWTransfers ? (gameweekInfo?.selected ?? currentGameweek) : null;
+  const { transfers: gwTransfers, meta: gwTransfersMeta, loading: gwTransfersLoading } = useGWTransfers(gwTransfersEntryId, gwTransfersGW);
+  const [gwTransfersExpanded, setGwTransfersExpanded] = useState(false);
+
+  // Aggregate in/out/net points across all GW transfers (uses allPlayers for basePoints)
+  const gwTransferPoints = useMemo(() => {
+    if (!gwTransfers.length || !allPlayers.length) return null;
+    const pMap = {};
+    allPlayers.forEach(p => { pMap[p.id] = p; });
+    let inTotal = 0, outTotal = 0, resolved = true;
+    for (const t of gwTransfers) {
+      const pIn  = pMap[t.playerIn.id];
+      const pOut = pMap[t.playerOut.id];
+      const inPts  = pIn  ? Math.round(pIn.basePoints  ?? pIn.predictedPoints  ?? pIn.event_points  ?? 0) : null;
+      const outPts = pOut ? Math.round(pOut.basePoints ?? pOut.predictedPoints ?? pOut.event_points ?? 0) : null;
+      if (inPts == null || outPts == null) { resolved = false; break; }
+      inTotal  += inPts;
+      outTotal += outPts;
+    }
+    return resolved ? { in: inTotal, out: outTotal, net: inTotal - outTotal } : null;
+  }, [gwTransfers, allPlayers]);
 
   const handleChipToggle = (chipId) => {
     const next = activeChip === chipId ? null : chipId;
@@ -676,6 +705,7 @@ const App = () => {
         isPast={ gameweekInfo?.isPast }
         isActive={ gameweekInfo?.isActive }
         gameweekLocked={ activeSection === 'active' || activeSection === 'next' }
+        activeSection={ activeSection }
       />
       <SectionBar
         activeSection={ activeSection }
@@ -774,7 +804,7 @@ const App = () => {
                 ) }
 
                 { /* Stats + controls grid */ }
-                <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: displayFreeTransfers != null || displayBank != null ? `1fr 1fr${ displayFreeTransfers != null ? ' 1fr' : '' }${ displayBank != null ? ' 1fr' : '' } 1fr` : '1fr 1fr 1fr', textAlign: 'center', rowGap: 0.75 } }>
+                <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: `1fr 1fr${ displayFreeTransfers != null ? ' 1fr' : '' }${ displayBank != null ? ' 1fr' : '' }${ showGWTransfers ? ' 1fr' : '' } 1fr`, textAlign: 'center', rowGap: 0.75 } }>
                   { /* Row 1 — labels */ }
                   <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
                     Total Points
@@ -791,6 +821,20 @@ const App = () => {
                     <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
                       In the Bank
                     </Typography>
+                  ) }
+                  { showGWTransfers && (
+                    <Box
+                      onClick={ gwTransfers.length > 0 ? () => setGwTransfersExpanded(e => !e) : undefined }
+                      sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 0.25, cursor: gwTransfers.length > 0 ? 'pointer' : 'default', userSelect: 'none' } }
+                    >
+                      <Typography variant='caption' color='text.secondary' sx={ { fontWeight: 500 } }>
+                        Transfers Made
+                      </Typography>
+                      { gwTransfers.length > 0 && (gwTransfersExpanded
+                        ? <ExpandLessIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
+                        : <ExpandMoreIcon sx={ { fontSize: 12, color: 'text.secondary' } } />
+                      ) }
+                    </Box>
                   ) }
                   <Box sx={ { display: 'flex', justifyContent: 'center' } }>
                     { !isHighestPredictedTeam && !viewingOpponentId && !isLockedGameweek && activePlayers.length > 0 ? (
@@ -876,6 +920,22 @@ const App = () => {
                       ) }
                     </Box>
                   ) }
+                  { showGWTransfers && (
+                    <Box
+                      onClick={ gwTransfers.length > 0 ? () => setGwTransfersExpanded(e => !e) : undefined }
+                      sx={ { display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', cursor: gwTransfers.length > 0 ? 'pointer' : 'default', userSelect: 'none' } }
+                    >
+                      { gwTransfersLoading
+                        ? <CircularProgress size={ 16 } />
+                        : <Typography variant='h6' sx={ { fontWeight: 700, lineHeight: 1.2 } }>{ gwTransfers.length }</Typography>
+                      }
+                      { gwTransferPoints != null && (
+                        <Typography variant='caption' sx={ { fontWeight: 700, lineHeight: 1, fontSize: '0.65rem', color: gwTransferPoints.net > 0 ? 'success.main' : gwTransferPoints.net < 0 ? 'error.main' : 'text.secondary' } }>
+                          { gwTransferPoints.net > 0 ? `+${gwTransferPoints.net}` : gwTransferPoints.net }pts
+                        </Typography>
+                      ) }
+                    </Box>
+                  ) }
                   <Box sx={ { display: 'flex', justifyContent: 'center', alignItems: 'center' } }>
                     <ToggleButtonGroup
                       value={ pitchView }
@@ -892,6 +952,17 @@ const App = () => {
                       </ToggleButton>
                     </ToggleButtonGroup>
                   </Box>
+                  { /* Row 3 — GW transfers collapse (spans all columns) */ }
+                  { showGWTransfers && gwTransfers.length > 0 && (
+                    <Box sx={ { gridColumn: '1 / -1', textAlign: 'left' } }>
+                      <GWTransfersPanel
+                        expanded={ gwTransfersExpanded }
+                        transfers={ gwTransfers }
+                        allPlayers={ allPlayers }
+                        meta={ gwTransfersMeta }
+                      />
+                    </Box>
+                  ) }
                 </Box>
               </Box>
               <Box sx={ { mt: 1, borderRadius: 2, overflow: 'hidden', bgcolor: 'background.paper' } }>

--- a/frontend/src/components/GWTransfers/GWTransfers.jsx
+++ b/frontend/src/components/GWTransfers/GWTransfers.jsx
@@ -10,8 +10,8 @@ import { useTheme } from '@mui/material/styles';
 import axios from '../../api';
 
 /**
- * Custom hook — fetches GW transfers for an entry and resolves actual points
- * from the allPlayers list.  Returns { transfers, loading, playerMap }.
+ * Custom hook — fetches GW transfers for an entry.
+ * Returns { transfers, meta, loading }.
  */
 export function useGWTransfers(entryId, gameweek) {
   const [transfers, setTransfers] = useState([]);
@@ -161,14 +161,14 @@ const GWTransfersPanel = ({ expanded, transfers, allPlayers, meta }) => {
                   Net: { netPoints > 0 ? `+${netPoints}` : netPoints }pts
                 </Typography>
               </Box>
-              { transferCost < 0 && (
+              { transferCost > 0 && (
                 <Box sx={ { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 0.75 } }>
                   <Typography variant='caption' color='text.secondary'>
                     { transfers.length } transfer{ transfers.length !== 1 ? 's' : '' } made
                   </Typography>
                   <Typography variant='caption' color='text.disabled'>·</Typography>
                   <Typography variant='caption' sx={ { fontWeight: 700, color: 'error.main' } }>
-                    { transferCost }pt{ Math.abs(transferCost) !== 1 ? 's' : '' } deduction
+                    -{ transferCost }pt{ transferCost !== 1 ? 's' : '' } deduction
                   </Typography>
                 </Box>
               ) }

--- a/frontend/src/components/GWTransfers/GWTransfers.jsx
+++ b/frontend/src/components/GWTransfers/GWTransfers.jsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
+import Tooltip from '@mui/material/Tooltip';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { useTheme } from '@mui/material/styles';
+import axios from '../../api';
+
+/**
+ * Custom hook — fetches GW transfers for an entry and resolves actual points
+ * from the allPlayers list.  Returns { transfers, loading, playerMap }.
+ */
+export function useGWTransfers(entryId, gameweek) {
+  const [transfers, setTransfers] = useState([]);
+  const [meta, setMeta] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!entryId || !gameweek) { setTransfers([]); setMeta(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    setTransfers([]);
+    setMeta(null);
+    axios
+      .get(`/api/entry/${entryId}/transfers?gameweek=${gameweek}`)
+      .then((res) => {
+        if (!cancelled) {
+          setTransfers(res.data.transfers ?? []);
+          setMeta(res.data.meta ?? null);
+        }
+      })
+      .catch(() => { if (!cancelled) { setTransfers([]); setMeta(null); } })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [entryId, gameweek]);
+
+  return { transfers, meta, loading };
+}
+
+/**
+ * Expandable transfer detail panel.
+ *
+ * Props:
+ *   expanded   – boolean controlled externally
+ *   transfers  – array from useGWTransfers
+ *   allPlayers – enriched player array for actual pts lookup
+ */
+const GWTransfersPanel = ({ expanded, transfers, allPlayers, meta }) => {
+  const theme = useTheme();
+
+  const playerMap = useMemo(() => {
+    const m = {};
+    if (allPlayers) allPlayers.forEach(p => { m[p.id] = p; });
+    return m;
+  }, [allPlayers]);
+
+  const getPoints = (id) => {
+    const p = playerMap[id];
+    if (!p) return null;
+    const raw = p.basePoints ?? p.predictedPoints ?? p.event_points;
+    return raw != null ? Math.round(raw) : null;
+  };
+
+  const netPoints = useMemo(() => {
+    if (!transfers.length) return null;
+    let net = 0;
+    for (const t of transfers) {
+      const inPts  = getPoints(t.playerIn.id);
+      const outPts = getPoints(t.playerOut.id);
+      if (inPts == null || outPts == null) return null;
+      net += inPts - outPts;
+    }
+    return net;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transfers, playerMap]);
+
+  if (!transfers.length) return null;
+
+  return (
+    <Collapse in={ expanded } unmountOnExit>
+      <Divider sx={ { mt: 0.5, mb: 1.5 } } />
+      <Box sx={ { display: 'flex', flexDirection: 'column', gap: 1.5, px: 2 } }>
+        { transfers.map((t, i) => {
+          const outPts = getPoints(t.playerOut.id);
+          const inPts  = getPoints(t.playerIn.id);
+          const diff   = inPts != null && outPts != null ? inPts - outPts : null;
+          return (
+            <Box
+              key={ i }
+              sx={ {
+                display: 'grid',
+                gridTemplateColumns: '1fr 48px 1fr',
+                alignItems: 'center',
+                px: 2,
+                py: 1.25,
+                borderRadius: 1.5,
+                bgcolor: theme.palette.action.hover,
+              } }
+            >
+              { /* Player out */ }
+              <Box sx={ { display: 'flex', flexDirection: 'column', alignItems: 'flex-end', minWidth: 0 } }>
+                <Tooltip title={ t.playerOut.name }>
+                  <Typography variant='body2' noWrap sx={ { color: 'error.main', fontWeight: 600, maxWidth: '100%' } }>
+                    { t.playerOut.webName }
+                  </Typography>
+                </Tooltip>
+                <Box sx={ { display: 'flex', gap: 1, alignItems: 'center', mt: 0.5 } }>
+                  <Typography variant='caption' color='text.secondary'>£{ (t.playerOut.cost / 10).toFixed(1) }m</Typography>
+                  { outPts != null && (
+                    <Typography variant='caption' sx={ { fontWeight: 600, color: 'text.primary' } }>{ outPts }pts</Typography>
+                  ) }
+                </Box>
+              </Box>
+              { /* Arrow + per-transfer diff */ }
+              <Box sx={ { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 } }>
+                <ArrowForwardIcon sx={ { fontSize: 16, color: 'text.disabled' } } />
+                { diff != null && (
+                  <Typography variant='caption' sx={ { fontWeight: 700, lineHeight: 1, color: diff > 0 ? 'success.main' : diff < 0 ? 'error.main' : 'text.secondary' } }>
+                    { diff > 0 ? `+${diff}` : diff }
+                  </Typography>
+                ) }
+              </Box>
+              { /* Player in */ }
+              <Box sx={ { display: 'flex', flexDirection: 'column', alignItems: 'flex-start', minWidth: 0 } }>
+                <Tooltip title={ t.playerIn.name }>
+                  <Typography variant='body2' noWrap sx={ { color: 'success.main', fontWeight: 600, maxWidth: '100%' } }>
+                    { t.playerIn.webName }
+                  </Typography>
+                </Tooltip>
+                <Box sx={ { display: 'flex', gap: 1, alignItems: 'center', mt: 0.5 } }>
+                  <Typography variant='caption' color='text.secondary'>£{ (t.playerIn.cost / 10).toFixed(1) }m</Typography>
+                  { inPts != null && (
+                    <Typography variant='caption' sx={ { fontWeight: 600, color: 'text.primary' } }>{ inPts }pts</Typography>
+                  ) }
+                </Box>
+              </Box>
+            </Box>
+          );
+        }) }
+        { /* Totals + net + transfer cost summary */ }
+        { netPoints != null && (() => {
+          let inTotal = 0, outTotal = 0;
+          for (const t of transfers) {
+            const ip = getPoints(t.playerIn.id);
+            const op = getPoints(t.playerOut.id);
+            if (ip != null) inTotal += ip;
+            if (op != null) outTotal += op;
+          }
+          const transferCost = meta?.transferCost ?? 0;
+          return (
+            <Box sx={ { display: 'flex', flexDirection: 'column', gap: 0.75, px: 1, pt: 0.25, pb: 1 } }>
+              <Box sx={ { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1.5 } }>
+                <Typography variant='caption' sx={ { fontWeight: 600, color: 'text.primary' } }>In: { inTotal }pts</Typography>
+                <Typography variant='caption' color='text.disabled'>·</Typography>
+                <Typography variant='caption' sx={ { fontWeight: 600, color: 'text.primary' } }>Out: { outTotal }pts</Typography>
+                <Typography variant='caption' color='text.disabled'>·</Typography>
+                <Typography variant='caption' sx={ { fontWeight: 700, color: netPoints > 0 ? 'success.main' : netPoints < 0 ? 'error.main' : 'text.secondary' } }>
+                  Net: { netPoints > 0 ? `+${netPoints}` : netPoints }pts
+                </Typography>
+              </Box>
+              { transferCost < 0 && (
+                <Box sx={ { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 0.75 } }>
+                  <Typography variant='caption' color='text.secondary'>
+                    { transfers.length } transfer{ transfers.length !== 1 ? 's' : '' } made
+                  </Typography>
+                  <Typography variant='caption' color='text.disabled'>·</Typography>
+                  <Typography variant='caption' sx={ { fontWeight: 700, color: 'error.main' } }>
+                    { transferCost }pt{ Math.abs(transferCost) !== 1 ? 's' : '' } deduction
+                  </Typography>
+                </Box>
+              ) }
+            </Box>
+          );
+        })() }
+      </Box>
+    </Collapse>
+  );
+};
+
+GWTransfersPanel.propTypes = {
+  expanded: PropTypes.bool,
+  transfers: PropTypes.array,
+  allPlayers: PropTypes.array,
+  meta: PropTypes.object,
+};
+
+export default GWTransfersPanel;

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -44,7 +44,7 @@ const NavigationBar = ({
   activeSection,
 }) => {
   const isPlanning = activeSection === 'planning';
-  const minSelectableGw = isPlanning && currentGameweek ? Math.min(currentGameweek + 1, MAX_GAMEWEEK) : 1;
+  const minSelectableGw = isPlanning && currentGameweek ? currentGameweek + 1 : 1;
   const selectableGwCount = Math.max(0, MAX_GAMEWEEK - minSelectableGw + 1);
   const { mode, toggleTheme, toggleWin2k, toggleTeletext } = useThemeMode();
   const [teamIdDialogOpen, setTeamIdDialogOpen] = React.useState(false);

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -30,6 +30,7 @@ const TEAM_VIEW = {
   USER: 'user',
   HIGHEST: 'highest'
 };
+const MAX_GAMEWEEK = 38;
 
 const NavigationBar = ({
   teamView,
@@ -43,8 +44,8 @@ const NavigationBar = ({
   activeSection,
 }) => {
   const isPlanning = activeSection === 'planning';
-  const minSelectableGw = isPlanning && currentGameweek ? Math.min(currentGameweek + 1, 38) : 1;
-  const selectableGwCount = Math.max(0, 38 - minSelectableGw + 1);
+  const minSelectableGw = isPlanning && currentGameweek ? Math.min(currentGameweek + 1, MAX_GAMEWEEK) : 1;
+  const selectableGwCount = Math.max(0, MAX_GAMEWEEK - minSelectableGw + 1);
   const { mode, toggleTheme, toggleWin2k, toggleTeletext } = useThemeMode();
   const [teamIdDialogOpen, setTeamIdDialogOpen] = React.useState(false);
   const [teamIdInput, setTeamIdInput] = React.useState('');
@@ -210,7 +211,7 @@ const NavigationBar = ({
                   <IconButton
                     size='small'
                     color='inherit'
-                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) >= 38 }
+                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) >= MAX_GAMEWEEK }
                     onClick={ () => {
                       const current = selectedGameweek || currentGameweek || 1;
                       setSelectedGameweek(current + 1 === currentGameweek ? null : current + 1);

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -40,7 +40,10 @@ const NavigationBar = ({
   setSelectedGameweek,
   currentGameweek,
   gameweekLocked,
+  activeSection,
 }) => {
+  const isPlanning = activeSection === 'planning';
+  const minSelectableGw = isPlanning && currentGameweek ? currentGameweek + 1 : 1;
   const { mode, toggleTheme, toggleWin2k, toggleTeletext } = useThemeMode();
   const [teamIdDialogOpen, setTeamIdDialogOpen] = React.useState(false);
   const [teamIdInput, setTeamIdInput] = React.useState('');
@@ -170,7 +173,7 @@ const NavigationBar = ({
                   <IconButton
                     size='small'
                     color='inherit'
-                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) <= 1 }
+                    disabled={ gameweekLocked || (selectedGameweek || currentGameweek || 1) <= minSelectableGw }
                     onClick={ () => {
                       const current = selectedGameweek || currentGameweek || 1;
                       setSelectedGameweek(current - 1 === currentGameweek ? null : current - 1);
@@ -194,7 +197,7 @@ const NavigationBar = ({
                     '& .MuiSelect-select': { py: 1 }
                   } }
                 >
-                  { Array.from({ length: 38 }, (_, i) => i + 1).map((gw) => (
+                  { Array.from({ length: 38 - minSelectableGw + 1 }, (_, i) => minSelectableGw + i).map((gw) => (
                     <MenuItem key={ gw } value={ gw }>
                       GW { gw }
                     </MenuItem>
@@ -278,6 +281,7 @@ NavigationBar.propTypes = {
   setSelectedGameweek: PropTypes.func,
   currentGameweek: PropTypes.number,
   gameweekLocked: PropTypes.bool,
+  activeSection: PropTypes.string,
 };
 
 export default NavigationBar;

--- a/frontend/src/components/NavigationBar/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar/NavigationBar.jsx
@@ -43,7 +43,8 @@ const NavigationBar = ({
   activeSection,
 }) => {
   const isPlanning = activeSection === 'planning';
-  const minSelectableGw = isPlanning && currentGameweek ? currentGameweek + 1 : 1;
+  const minSelectableGw = isPlanning && currentGameweek ? Math.min(currentGameweek + 1, 38) : 1;
+  const selectableGwCount = Math.max(0, 38 - minSelectableGw + 1);
   const { mode, toggleTheme, toggleWin2k, toggleTeletext } = useThemeMode();
   const [teamIdDialogOpen, setTeamIdDialogOpen] = React.useState(false);
   const [teamIdInput, setTeamIdInput] = React.useState('');
@@ -197,7 +198,7 @@ const NavigationBar = ({
                     '& .MuiSelect-select': { py: 1 }
                   } }
                 >
-                  { Array.from({ length: 38 - minSelectableGw + 1 }, (_, i) => minSelectableGw + i).map((gw) => (
+                  { Array.from({ length: selectableGwCount }, (_, i) => minSelectableGw + i).map((gw) => (
                     <MenuItem key={ gw } value={ gw }>
                       GW { gw }
                     </MenuItem>


### PR DESCRIPTION
This pull request introduces a new feature that enables users to view detailed Gameweek (GW) transfer history—including player names, costs, and actual points in/out—for themselves or opponents in the Fantasy Premier League (FPL) app. The backend now provides a new API endpoint to fetch this data, and the frontend displays it in an expandable panel within the main team view. Additionally, the player enrichment logic is refined to ensure accurate point calculations for past and active gameweeks.

The most important changes are:

**Backend: Gameweek Transfers API**

* Added a new endpoint (`/api/entry/:entryId/transfers?gameweek=N`) that returns all transfers made by a user for a specific gameweek, including resolved player names and costs, and includes transfer cost metadata when available. (`backend/controllers/fplController.js` [[1]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR1342-R1425) [[2]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR1442); `backend/server.js` [[3]](diffhunk://#diff-e6a1d92480cd16cd30155f4e1694f991d54adcc2ad6611395c7798452f71af72R32)

* Improved player enrichment so that, for past or active gameweeks, actual points are fetched from the live endpoint, ensuring that event points reflect true GW scores. Advanced predictions are now only applied for future gameweeks. (`backend/controllers/fplController.js` [backend/controllers/fplController.jsR733-R747](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR733-R747))

**Frontend: Display and Aggregation of GW Transfers**

* Introduced a new `GWTransfersPanel` component and `useGWTransfers` hook to fetch, display, and summarize GW transfers, including per-transfer and net points, player names, and costs. (`frontend/src/components/GWTransfers/GWTransfers.jsx` [frontend/src/components/GWTransfers/GWTransfers.jsxR1-R190](diffhunk://#diff-da4322448d361733fb68cc0ab9ce058f23c75950b1480bda1cde22b04324cf5cR1-R190))

* Updated the main app view (`App.jsx`) to:
  - Show a "Transfers Made" column in the stats grid for relevant views, with an expandable panel listing detailed transfer info.
  - Aggregate and display total in/out/net points for all GW transfers, using actual or predicted points as appropriate.
  - Add loading states and expand/collapse UI for transfer details. (`frontend/src/App.jsx` [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R21-R23) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R38) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R91-R115) [[4]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L777-R807) [[5]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R923-R938) [[6]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R825-R838) [[7]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R955-R965)

**Navigation Bar**

* Passed the `activeSection` prop to the navigation bar and adjusted minimum selectable gameweek logic for planning mode. (`frontend/src/components/NavigationBar/NavigationBar.jsx` [[1]](diffhunk://#diff-c4a18fac63fcb75da324e98dfdadd50d212df8cc749df1d0a7d23262d1b43134R43-R46); `frontend/src/App.jsx` [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R708)

These changes collectively provide a much more informative and interactive experience around transfer activity, helping users analyze the impact of their (or their rivals') moves in each gameweek.