### PR TITLE
Refactor gameweek selection and update display format in RecommendedTransfers

### DIFF
--- a/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
+++ b/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
@@ -102,11 +102,13 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
               onChange={ handleGameweekChange }
               label='Period'
             >
-              <MenuItem value={ 1 }>GW { currentGameweek + 1 }</MenuItem>
-              <MenuItem value={ 2 }>Next 2 GWs</MenuItem>
-              <MenuItem value={ 3 }>Next 3 GWs</MenuItem>
-              <MenuItem value={ 4 }>Next 4 GWs</MenuItem>
-              <MenuItem value={ 5 }>Next 5 GWs</MenuItem>
+              { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
+                <MenuItem key={ n } value={ n }>
+                  { n === 1
+                    ? `Next Gameweek ${ currentGameweek + 1 }`
+                    : `Next Gameweek ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                </MenuItem>
+              )) }
             </Select>
           </FormControl>
         </Box>
@@ -133,11 +135,13 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                 onChange={ handleGameweekChange }
                 label='Forecast Period'
               >
-                <MenuItem value={ 1 }>Next GW ({ currentGameweek + 1 })</MenuItem>
-                <MenuItem value={ 2 }>Next 2 GWs (Cumulative)</MenuItem>
-                <MenuItem value={ 3 }>Next 3 GWs (Cumulative)</MenuItem>
-                <MenuItem value={ 4 }>Next 4 GWs (Cumulative)</MenuItem>
-                <MenuItem value={ 5 }>Next 5 GWs (Cumulative)</MenuItem>
+                { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
+                  <MenuItem key={ n } value={ n }>
+                    { n === 1
+                      ? `Next Gameweek ${ currentGameweek + 1 }`
+                      : `Next Gameweek ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                  </MenuItem>
+                )) }
               </Select>
             </FormControl>
           </Box>
@@ -191,7 +195,7 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                   { displayRecs.map((rec, idx) => {
                     const filteredAlternatives = filterAlternativesByPrice(rec.alternatives, rec.playerOut.now_cost);
                     if (filteredAlternatives.length === 0) return null;
-                    const altsToShow = filteredAlternatives.slice(0, 3);
+                    const altsToShow = filteredAlternatives.slice(0, 2);
                     return (
                       <Box key={ idx }>
                         { idx > 0 && <Divider sx={ { my: 1 } } /> }
@@ -209,8 +213,8 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                               { Math.round(rec.playerOut.predicted_points) } pts · £{ (rec.playerOut.now_cost / 10).toFixed(1) }m
                             </Typography>
                           </Box>
-                          { /* IN — 3-column grid */ }
-                          <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, pl: 0.75, minWidth: 0 } }>
+                          { /* IN — 2-column grid */ }
+                          <Box sx={ { flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, pl: 0.75, minWidth: 0 } }>
                             { altsToShow.map((alt, altIdx) => (
                               <Box key={ altIdx } sx={ { minWidth: 0 } }>
                                 <Typography variant='body2' fontWeight='bold' noWrap>
@@ -291,7 +295,7 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                                 ) }
                               </Box>
                             </TableCell>
-                            { filteredAlternatives.slice(0, 3).map((alt, altIdx) => (
+                            { filteredAlternatives.slice(0, 2).map((alt, altIdx) => (
                               <TableCell key={ altIdx } sx={ { minWidth: 180 } }>
                                 <Box>
                                   <Typography variant='body2' fontWeight='bold'>
@@ -315,8 +319,8 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                                 </Box>
                               </TableCell>
                             )) }
-                            { /* Fill empty cells if less than 3 alternatives */ }
-                            { filteredAlternatives.length < 3 && [...Array(3 - filteredAlternatives.length)].map((_, emptyIdx) => (
+                            { /* Fill empty cells if less than 2 alternatives */ }
+                            { filteredAlternatives.length < 2 && [...Array(2 - filteredAlternatives.length)].map((_, emptyIdx) => (
                               <TableCell key={ `empty-${emptyIdx}` } sx={ { minWidth: 180 } } />
                             )) }
                           </TableRow>

--- a/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
+++ b/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
@@ -38,15 +38,34 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
   const [recommendations, setRecommendations] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const maxGameweeksAhead = Math.max(0, Math.min(5, 38 - currentGameweek));
+  const forecastPeriodOptions = Array.from({ length: maxGameweeksAhead }, (_, i) => i + 1);
+  const normalizedGameweeksAhead = maxGameweeksAhead === 0
+    ? ''
+    : Math.min(Math.max(gameweeksAhead, 1), maxGameweeksAhead);
+
+  useEffect(() => {
+    if (maxGameweeksAhead === 0) {
+      if (gameweeksAhead !== 0) setGameweeksAhead(0);
+      return;
+    }
+
+    if (gameweeksAhead < 1 || gameweeksAhead > maxGameweeksAhead) {
+      setGameweeksAhead(maxGameweeksAhead);
+    }
+  }, [gameweeksAhead, maxGameweeksAhead]);
 
   const fetchRecommendations = useCallback(async () => {
-    if (!entryId || !currentGameweek) return;
+    if (!entryId || !currentGameweek || maxGameweeksAhead === 0 || normalizedGameweeksAhead === '') {
+      setRecommendations(null);
+      return;
+    }
     
     setLoading(true);
     setError(null);
     try {
       const response = await axios.get(
-        `/api/entry/${entryId}/event/${currentGameweek}/recommended-transfers?gameweeksAhead=${gameweeksAhead}`
+        `/api/entry/${entryId}/event/${currentGameweek}/recommended-transfers?gameweeksAhead=${normalizedGameweeksAhead}`
       );
       setRecommendations(response.data);
     } catch (err) {
@@ -55,14 +74,14 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
     } finally {
       setLoading(false);
     }
-  }, [entryId, currentGameweek, gameweeksAhead]);
+  }, [entryId, currentGameweek, maxGameweeksAhead, normalizedGameweeksAhead]);
 
   useEffect(() => {
     fetchRecommendations();
   }, [fetchRecommendations]);
 
   const handleGameweekChange = (event) => {
-    setGameweeksAhead(event.target.value);
+    setGameweeksAhead(Number(event.target.value));
   };
 
   const handleSimilarPricingToggle = (event) => {
@@ -95,22 +114,28 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
           <Typography variant='h6' fontWeight='bold'>
             Recommended Transfers
           </Typography>
-          <FormControl size='small' sx={ { minWidth: 0, flex: '1 1 auto', maxWidth: 180 } }>
-            <InputLabel>Period</InputLabel>
-            <Select
-              value={ gameweeksAhead }
-              onChange={ handleGameweekChange }
-              label='Period'
-            >
-              { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
-                <MenuItem key={ n } value={ n }>
-                  { n === 1
-                    ? `GW${ currentGameweek + 1 }`
-                    : `GW${ currentGameweek + 1 }-${ currentGameweek + n }` }
-                </MenuItem>
-              )) }
-            </Select>
-          </FormControl>
+          { maxGameweeksAhead > 0 ? (
+            <FormControl size='small' sx={ { minWidth: 0, flex: '1 1 auto', maxWidth: 180 } }>
+              <InputLabel>Period</InputLabel>
+              <Select
+                value={ normalizedGameweeksAhead }
+                onChange={ handleGameweekChange }
+                label='Period'
+              >
+                { forecastPeriodOptions.map(n => (
+                  <MenuItem key={ n } value={ n }>
+                    { n === 1
+                      ? `GW ${ currentGameweek + 1 }`
+                      : `GW ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                  </MenuItem>
+                )) }
+              </Select>
+            </FormControl>
+          ) : (
+            <Typography variant='body2' color='text.secondary'>
+              No future gameweeks
+            </Typography>
+          ) }
         </Box>
       ) : (
         <Box sx={ { display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 2 } }>
@@ -128,22 +153,28 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
               }
               label='Similar Pricing'
             />
-            <FormControl size='small' sx={ { minWidth: 200 } }>
-              <InputLabel>Forecast Period</InputLabel>
-              <Select
-                value={ gameweeksAhead }
-                onChange={ handleGameweekChange }
-                label='Forecast Period'
-              >
-                { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
-                  <MenuItem key={ n } value={ n }>
-                    { n === 1
-                      ? `GW${ currentGameweek + 1 }`
-                      : `GW${ currentGameweek + 1 }-${ currentGameweek + n }` }
-                  </MenuItem>
-                )) }
-              </Select>
-            </FormControl>
+            { maxGameweeksAhead > 0 ? (
+              <FormControl size='small' sx={ { minWidth: 200 } }>
+                <InputLabel>Forecast Period</InputLabel>
+                <Select
+                  value={ normalizedGameweeksAhead }
+                  onChange={ handleGameweekChange }
+                  label='Forecast Period'
+                >
+                  { forecastPeriodOptions.map(n => (
+                    <MenuItem key={ n } value={ n }>
+                      { n === 1
+                        ? `GW ${ currentGameweek + 1 }`
+                        : `GW ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                    </MenuItem>
+                  )) }
+                </Select>
+              </FormControl>
+            ) : (
+              <Typography variant='body2' color='text.secondary'>
+                No future gameweeks
+              </Typography>
+            ) }
           </Box>
         </Box>
       ) }

--- a/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
+++ b/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
@@ -30,6 +30,7 @@ const positionLabels = {
   MID: 'MID',
   ATT: 'FWD'
 };
+const TOTAL_GAMEWEEKS = 38;
 
 const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => {
   const theme = useTheme();
@@ -38,25 +39,16 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
   const [recommendations, setRecommendations] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const maxGameweeksAhead = Math.max(0, Math.min(5, 38 - currentGameweek));
-  const forecastPeriodOptions = Array.from({ length: maxGameweeksAhead }, (_, i) => i + 1);
+  const maxGameweeksAhead = Math.max(0, Math.min(5, TOTAL_GAMEWEEKS - currentGameweek));
+  const forecastPeriodOptions = maxGameweeksAhead > 0
+    ? Array.from({ length: maxGameweeksAhead }, (_, i) => i + 1)
+    : [];
   const normalizedGameweeksAhead = maxGameweeksAhead === 0
-    ? ''
+    ? 0
     : Math.min(Math.max(gameweeksAhead, 1), maxGameweeksAhead);
 
-  useEffect(() => {
-    if (maxGameweeksAhead === 0) {
-      if (gameweeksAhead !== 0) setGameweeksAhead(0);
-      return;
-    }
-
-    if (gameweeksAhead < 1 || gameweeksAhead > maxGameweeksAhead) {
-      setGameweeksAhead(maxGameweeksAhead);
-    }
-  }, [gameweeksAhead, maxGameweeksAhead]);
-
   const fetchRecommendations = useCallback(async () => {
-    if (!entryId || !currentGameweek || maxGameweeksAhead === 0 || normalizedGameweeksAhead === '') {
+    if (!entryId || !currentGameweek || maxGameweeksAhead === 0 || normalizedGameweeksAhead === 0) {
       setRecommendations(null);
       return;
     }
@@ -81,7 +73,10 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
   }, [fetchRecommendations]);
 
   const handleGameweekChange = (event) => {
-    setGameweeksAhead(Number(event.target.value));
+    const nextValue = Number(event.target.value);
+    if (Number.isFinite(nextValue) && nextValue >= 1 && nextValue <= maxGameweeksAhead) {
+      setGameweeksAhead(nextValue);
+    }
   };
 
   const handleSimilarPricingToggle = (event) => {

--- a/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
+++ b/frontend/src/components/RecommendedTransfers/RecommendedTransfers.jsx
@@ -105,8 +105,8 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
               { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
                 <MenuItem key={ n } value={ n }>
                   { n === 1
-                    ? `Next Gameweek ${ currentGameweek + 1 }`
-                    : `Next Gameweek ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                    ? `GW${ currentGameweek + 1 }`
+                    : `GW${ currentGameweek + 1 }-${ currentGameweek + n }` }
                 </MenuItem>
               )) }
             </Select>
@@ -138,8 +138,8 @@ const RecommendedTransfers = ({ entryId, currentGameweek, compact = false }) => 
                 { Array.from({ length: Math.min(5, 38 - currentGameweek) }, (_, i) => i + 1).map(n => (
                   <MenuItem key={ n } value={ n }>
                     { n === 1
-                      ? `Next Gameweek ${ currentGameweek + 1 }`
-                      : `Next Gameweek ${ currentGameweek + 1 }-${ currentGameweek + n }` }
+                      ? `GW${ currentGameweek + 1 }`
+                      : `GW${ currentGameweek + 1 }-${ currentGameweek + n }` }
                   </MenuItem>
                 )) }
               </Select>


### PR DESCRIPTION
This pull request updates the `RecommendedTransfers` component to make the selection of forecast periods more dynamic and simplifies the display of alternative transfer recommendations. The main themes are improving flexibility in period selection and streamlining the UI for alternatives.

**Dynamic period selection:**
* Replaces hardcoded forecast period options in the period selection dropdowns with a dynamic list that adjusts based on the current gameweek, ensuring only valid future periods are shown. [[1]](diffhunk://#diff-8f20d581c9d47d0c028bff3ea59d04ba31a594c85c3846e89c64605c5d586a8dL105-R111) [[2]](diffhunk://#diff-8f20d581c9d47d0c028bff3ea59d04ba31a594c85c3846e89c64605c5d586a8dL136-R144)

**UI simplification for alternatives:**
* Reduces the number of alternative player recommendations shown from three to two in both the grid and table views, making the UI less cluttered. [[1]](diffhunk://#diff-8f20d581c9d47d0c028bff3ea59d04ba31a594c85c3846e89c64605c5d586a8dL194-R198) [[2]](diffhunk://#diff-8f20d581c9d47d0c028bff3ea59d04ba31a594c85c3846e89c64605c5d586a8dL294-R298)
* Updates the grid layout from three columns to two columns to match the reduced number of alternatives.
* Adjusts the logic for filling empty table cells to account for a maximum of two alternatives instead of three.