### PR TITLE
Implement caching for pre-computed predictions fetching

### DIFF
--- a/.github/scripts/fetch-season-data.js
+++ b/.github/scripts/fetch-season-data.js
@@ -20,14 +20,21 @@ const https   = require('https');
 const fs      = require('fs');
 const path    = require('path');
 
-const API_BASE     = process.env.FPL_API_BASE || 'https://fantasy.premierleague.com/api';
-const OUT_DIR      = path.join(__dirname, '..', '..', 'backend', 'seasonData');
-const LIVE_DIR     = path.join(OUT_DIR, 'live');
-const PLAYERS_DIR  = path.join(OUT_DIR, 'players');
+// Set env vars BEFORE requiring any backend models so dataProvider reads them
+// at module-load time and uses the committed seasonData/ files.
+process.env.CACHE_STATIC = 'true';
+process.env.USE_FPL_API  = 'true';
+
+const API_BASE        = process.env.FPL_API_BASE || 'https://fantasy.premierleague.com/api';
+const OUT_DIR         = path.join(__dirname, '..', '..', 'backend', 'seasonData');
+const LIVE_DIR        = path.join(OUT_DIR, 'live');
+const PLAYERS_DIR     = path.join(OUT_DIR, 'players');
+const PREDICTIONS_DIR = path.join(OUT_DIR, 'predictions');
 
 // Ensure output directories exist
 fs.mkdirSync(LIVE_DIR, { recursive: true });
 fs.mkdirSync(PLAYERS_DIR, { recursive: true });
+fs.mkdirSync(PREDICTIONS_DIR, { recursive: true });
 
 // ── HTTP helper ────────────────────────────────────────────────────────────
 
@@ -142,18 +149,29 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
   for (const gw of completedGws) {
     const filePath = path.join(LIVE_DIR, `gw-${gw}.json`);
+    const expectedFixtureCount = (fixturesByEvent[gw] || []).length;
 
-    // Skip if already present — completed GWs don't change
+    // Skip if already present — but re-fetch if the fixture count has changed
+    // (handles rescheduled matches being added to a GW after the file was written).
     if (fs.existsSync(filePath)) {
-      process.stdout.write(`  GW${gw}: cached ✓\n`);
-      continue;
+      try {
+        const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        const coveredFixtures = existing._fixture_count ?? Infinity; // legacy files treated as complete
+        if (coveredFixtures >= expectedFixtureCount) {
+          process.stdout.write(`  GW${gw}: cached ✓\n`);
+          continue;
+        }
+        process.stdout.write(`  GW${gw}: fixture count changed (${coveredFixtures} → ${expectedFixtureCount}), re-fetching...\n`);
+      } catch (_) {
+        // Corrupt file — re-fetch
+      }
     }
 
     try {
       await sleep(300); // be polite to the FPL API
       process.stdout.write(`  GW${gw}: fetching...`);
       const live = await fetchJson(`${API_BASE}/event/${gw}/live/`);
-      writeJson(filePath, live);
+      writeJson(filePath, { ...live, _fixture_count: expectedFixtureCount });
       process.stdout.write(` ${live.elements?.length ?? '?'} elements ✓\n`);
     } catch (err) {
       process.stdout.write(` FAILED: ${err.message}\n`);
@@ -190,14 +208,94 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     console.log('\nNo current/next event found — skipping player snapshot.');
   }
 
-  // ── 5. Summary ───────────────────────────────────────────────────────────
-  const liveFiles    = fs.readdirSync(LIVE_DIR).filter((f) => f.endsWith('.json')).length;
-  const playerFiles  = fs.readdirSync(PLAYERS_DIR).filter((f) => f.endsWith('.json')).length;
+  // ── 5. Pre-compute predictions for the next/current GW ──────────────────
+  // Predictions are only meaningful for a GW that hasn't finished yet.
+  // Once a GW concludes its prediction file is stale and will never be served
+  // to users, so we skip the expensive computation and delete the old file.
+  //
+  // Stored at: seasonData/predictions/gw-{n}.json  (overwritten each run
+  // while the GW is active; deleted once the GW finishes)
+  // Contains:  { gwId, computedAt, players: { [id]: { predicted_points, ... } } }
+
+  // Clean up prediction files for GWs that are now concluded
+  if (completedGws.length > 0) {
+    for (const gw of completedGws) {
+      const stale = path.join(PREDICTIONS_DIR, `gw-${gw}.json`);
+      if (fs.existsSync(stale)) {
+        fs.unlinkSync(stale);
+        console.log(`\nDeleted stale prediction file for concluded GW${gw}.`);
+      }
+    }
+  }
+
+  // Only compute predictions for a GW that is still upcoming / active
+  const targetEvent = events.find((ev) => ev.is_next) || events.find((ev) => ev.is_current);
+  const targetIsFinished = targetEvent
+    ? (targetEvent.finished === true || completedGws.includes(targetEvent.id))
+    : true;
+
+  if (targetEvent && !targetIsFinished) {
+    try {
+      console.log(`\nComputing predictions for GW${targetEvent.id}...`);
+
+      // Lazy-require after env vars are set and all files are written
+      const backtestEngine   = require('../../backend/models/prediction/backtestEngine');
+      const predictionEngine = require('../../backend/models/predictionEngine');
+
+      const players = bootstrap.elements || [];
+      const teams   = bootstrap.teams    || [];
+
+      // Run full backtest calibration against all available completed GWs
+      await backtestEngine.runBacktestAndCalibrate(players, fixtures, teams, targetEvent.id);
+
+      // Compute predictions with calibration applied
+      const predicted = predictionEngine.computePredictions(players, fixtures, teams, targetEvent.id);
+
+      // Store only the prediction-specific fields keyed by player ID
+      const PREDICTION_FIELDS = [
+        'ep_next', 'predicted_points', 'expected_goals', 'expected_assists',
+        'clean_sheet_probability', 'expected_minutes', 'expected_saves',
+        'yellow_card_probability', 'red_card_probability', 'bonus_probability',
+        'confidence_score', 'floor_points', 'ceiling_points',
+        'fixture_count', 'form_factor', 'calibration_applied',
+      ];
+
+      const playerMap = {};
+      predicted.forEach((p) => {
+        const entry = {};
+        PREDICTION_FIELDS.forEach((f) => { if (p[f] !== undefined) entry[f] = p[f]; });
+        playerMap[p.id] = entry;
+      });
+
+      const predFile = path.join(PREDICTIONS_DIR, `gw-${targetEvent.id}.json`);
+      writeJson(predFile, {
+        gwId:        targetEvent.id,
+        computedAt:  new Date().toISOString(),
+        playerCount: predicted.length,
+        players:     playerMap,
+      });
+
+      console.log(`  → GW${targetEvent.id} predictions written (${predicted.length} players).`);
+    } catch (err) {
+      console.error(`  Prediction computation failed: ${err.message}`);
+      // Non-fatal — live computation will run at request time
+    }
+  } else if (!targetEvent) {
+    console.log('\nNo upcoming GW found — skipping prediction computation.');
+  } else {
+    console.log(`\nGW${targetEvent.id} already concluded — skipping prediction computation.`);
+  }
+
+  // ── 6. Summary ───────────────────────────────────────────────────────────
+  const liveFiles       = fs.readdirSync(LIVE_DIR).filter((f) => f.endsWith('.json')).length;
+  const playerFiles     = fs.readdirSync(PLAYERS_DIR).filter((f) => f.endsWith('.json')).length;
+  const predFiles       = fs.readdirSync(PREDICTIONS_DIR).filter((f) => f.endsWith('.json')).length;
   console.log(`\nDone. Files written:`);
   console.log(`  backend/seasonData/bootstrap-static.json`);
   console.log(`  backend/seasonData/fixtures.json`);
-  console.log(`  backend/seasonData/live/     (${liveFiles} GW file(s))`);
-  console.log(`  backend/seasonData/players/  (${playerFiles} GW snapshot(s))`);
+  console.log(`  backend/seasonData/live/        (${liveFiles} GW file(s))`);
+  console.log(`  backend/seasonData/players/     (${playerFiles} GW snapshot(s))`);
+  console.log(`  backend/seasonData/predictions/ (${predFiles} prediction file(s))`);
 })().catch((err) => {
   console.error('\nFetch failed:', err.message);
   process.exit(1);

--- a/.github/scripts/fetch-season-data.js
+++ b/.github/scripts/fetch-season-data.js
@@ -156,7 +156,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     if (fs.existsSync(filePath)) {
       try {
         const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-        const coveredFixtures = existing._fixture_count ?? Infinity; // legacy files treated as complete
+        const coveredFixtures = existing._fixture_count ?? 0; // legacy files treated as unknown — force re-fetch to backfill _fixture_count
         if (coveredFixtures >= expectedFixtureCount) {
           process.stdout.write(`  GW${gw}: cached ✓\n`);
           continue;

--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -743,7 +743,36 @@ const getAllPlayersEnriched = async (req, res) => {
     
     // Apply the advanced prediction engine for future gameweeks only.
     if (!isPastOrActive) {
-      players = await fplModel.applyAdvancedPredictions(players, fixtures, data.teams, targetEvent);
+      // Try to serve pre-computed predictions written by the daily Actions workflow.
+      // This avoids the full backtest + engine run on every cold start.
+      //
+      // Staleness guard: reject files older than 13 h (just over one Actions
+      // interval).  This ensures a fixture postponement or reschedule is picked
+      // up within at most one Actions cycle rather than serving indefinitely
+      // stale predictions.
+      const MAX_PREDICTION_AGE_MS = 13 * 60 * 60 * 1000;
+      const stored = await dataProvider.fetchStoredPredictions(targetEvent);
+      const storedAge = stored?.computedAt
+        ? Date.now() - new Date(stored.computedAt).getTime()
+        : Infinity;
+      const storedValid =
+        stored &&
+        stored.players &&
+        Object.keys(stored.players).length > 0 &&
+        storedAge < MAX_PREDICTION_AGE_MS;
+
+      if (storedValid) {
+        console.log(`[enriched] Serving stored predictions for GW${targetEvent} (computed ${stored.computedAt})`);
+        players = players.map((p) => {
+          const pred = stored.players[p.id];
+          return pred ? { ...p, ...pred } : p;
+        });
+      } else {
+        if (stored && storedAge >= MAX_PREDICTION_AGE_MS) {
+          console.warn(`[enriched] Stored predictions for GW${targetEvent} are stale (${Math.round(storedAge / 3600000)}h old) — recomputing.`);
+        }
+        players = await fplModel.applyAdvancedPredictions(players, fixtures, data.teams, targetEvent);
+      }
     }
 
     // Add a pre-formatted opponent display string so the frontend does not need

--- a/backend/models/dataProvider.js
+++ b/backend/models/dataProvider.js
@@ -347,6 +347,33 @@ const fetchGwPlayerSnapshot = async (gwId) => {
 };
 
 /**
+ * Fetch pre-computed predictions for a GW written by the GitHub Actions
+ * workflow.  Returns an object shaped as:
+ *
+ *   { gwId, computedAt, playerCount, players: { [playerId]: { predicted_points, ... } } }
+ *
+ * Returns null when no stored prediction exists (caller falls back to live
+ * computation).
+ *
+ * @param {number|string} gwId - Gameweek ID
+ * @returns {Promise<Object|null>}
+ */
+const fetchStoredPredictions = async (gwId) => {
+  const validatedGwId = validateGameweek(gwId);
+
+  if (!CACHE_STATIC) return null; // Only used in static-cache mode
+
+  try {
+    return await loadJsonFile(
+      path.join(SEASON_DATA_DIR, 'predictions'),
+      `gw-${validatedGwId}.json`,
+    );
+  } catch (_) {
+    return null; // Not yet generated for this GW
+  }
+};
+
+/**
  * Fetch entry (user profile) data
  * @param {number|string} entryId - FPL entry/team ID
  * @returns {Promise<any>} - Entry data
@@ -425,6 +452,7 @@ module.exports = {
   fetchEventFixtures,
   fetchLiveGameweek,
   fetchGwPlayerSnapshot,
+  fetchStoredPredictions,
   fetchEntry,
   fetchHistory,
   fetchEntryTransfers,

--- a/backend/models/prediction/backtestEngine.js
+++ b/backend/models/prediction/backtestEngine.js
@@ -8,18 +8,18 @@
  * calibration multipliers.
  *
  * Flow:
- *   1. Identify the last N_BACKTEST_GWS fully-completed gameweeks
+ *   1. Identify ALL fully-completed gameweeks before the target GW
  *   2. For each, call computePredictions() in RAW mode (no calibration applied)
+ *      using the per-GW player snapshot if one was committed by the workflow,
+ *      falling back to current bootstrap data for GWs without a snapshot.
  *   3. Fetch the actual player points from event/{gw}/live/
- *   4. Aggregate prediction errors per position (with recency weighting)
+ *   4. Aggregate prediction errors per position using exponential decay weights
+ *      so recent GWs dominate but all available history shapes the calibration.
  *   5. Hand the aggregate stats to calibrationStore.update()
  *
- * The backtest is intentionally run with the *current* season stats as the
- * player baseline.  This introduces a small forward-looking bias, but:
- *   - The calibration is detecting *systematic positional bias* not individual
- *     player variance — the bias correction is still valid and useful.
- *   - Players whose stats changed significantly in the last 3 GWs benefit
- *     from that change being reflected in the form model anyway.
+ * Using all available GWs (rather than just the last 3) gives the calibration
+ * store enough data to detect stable systematic positional biases while the
+ * exponential decay ensures the multipliers react quickly to recent trends.
  *
  * Results are cached for CACHE_TTL_MS to avoid redundant API calls.
  */
@@ -30,9 +30,6 @@ const calibrationStore = require('./calibrationStore');
 // Imported lazily (via require inside the function) to avoid circular dep
 // with predictionEngine which requires this module indirectly.
 
-/** Number of recent completed GWs to include in each backtest run */
-const N_BACKTEST_GWS = 3;
-
 /**
  * Minimum actual minutes for a player to be included in calibration.
  * Excluding sub appearances and DNPs keeps the comparison fair.
@@ -40,10 +37,21 @@ const N_BACKTEST_GWS = 3;
 const MIN_MINUTES = 45;
 
 /**
- * Recency weights for the three tested GWs (most recent first).
- * Must sum to 1.0.
+ * Exponential decay factor for per-GW recency weighting.
+ * A value of 0.82 gives the most-recent GW roughly 3× the weight of a GW
+ * 6 weeks ago, while still letting older history meaningfully contribute.
+ *
+ * Weights are normalised to sum to 1.0 across however many GWs are tested,
+ * so adding more history never dilutes the total contribution.
  */
-const GW_WEIGHTS = [0.50, 0.35, 0.15];
+const DECAY = 0.82;
+
+/** Compute normalised exponential-decay weights for n GWs (index 0 = most recent). */
+const buildGwWeights = (n) => {
+  const raw = Array.from({ length: n }, (_, i) => Math.pow(DECAY, i));
+  const sum = raw.reduce((a, b) => a + b, 0);
+  return raw.map((w) => w / sum);
+};
 
 /** How long to cache a completed backtest run (ms). */
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -69,7 +77,7 @@ let _inFlightRun    = null;
  * @param {number} n          - Number of GWs to return
  * @returns {number[]} GW IDs, most recent first
  */
-const getRecentCompletedGws = (fixtures, targetGwId, n) => {
+const getRecentCompletedGws = (fixtures, targetGwId) => {
   // Group fixtures by event
   const byEvent = {};
   fixtures.forEach((f) => {
@@ -85,8 +93,7 @@ const getRecentCompletedGws = (fixtures, targetGwId, n) => {
       return fxs.every((f) => f.finished === true);
     })
     .map(([event]) => Number(event))
-    .sort((a, b) => b - a) // most recent first
-    .slice(0, n);
+    .sort((a, b) => b - a); // most recent first
 };
 
 /**
@@ -151,14 +158,15 @@ const runBacktestAndCalibrate = async (players, fixtures, teams, currentGwId) =>
   }
 
   const runPromise = (async () => {
-    const gwsToTest = getRecentCompletedGws(fixtures, currentGwId, N_BACKTEST_GWS);
+    const gwsToTest = getRecentCompletedGws(fixtures, currentGwId);
 
     if (gwsToTest.length === 0) {
       console.log('[Backtest] No completed GWs available — skipping calibration.');
       return { gwsTested: [], summary: {} };
     }
 
-    console.log(`[Backtest] Running against GW(s): ${gwsToTest.join(', ')}`);
+    const gwWeights = buildGwWeights(gwsToTest.length);
+    console.log(`[Backtest] Running against ${gwsToTest.length} GW(s): ${gwsToTest.join(', ')}`);
 
     // Build position lookup: playerId → element_type
     // (built from current players; updated per-GW below if a snapshot exists)
@@ -177,7 +185,7 @@ const runBacktestAndCalibrate = async (players, fixtures, teams, currentGwId) =>
 
     for (let i = 0; i < gwsToTest.length; i++) {
       const gw     = gwsToTest[i];
-      const weight = GW_WEIGHTS[i] ?? 0.10;
+      const weight = gwWeights[i];
 
       // Use a per-GW player snapshot if one was captured by the daily fetch
       // workflow.  This eliminates the forward-looking bias that arises from

--- a/backend/models/prediction/backtestEngine.js
+++ b/backend/models/prediction/backtestEngine.js
@@ -67,15 +67,14 @@ let _inFlightRun    = null;
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
- * Find the N most recent fully-completed gameweeks before targetGwId.
+ * Find all fully-completed gameweeks before targetGwId.
  *
  * A GW is "fully completed" when every fixture in that event has
  * `finished === true`.
  *
  * @param {Array}  fixtures   - Full fixtures array
  * @param {number} targetGwId - GW we are predicting (excluded from backtest)
- * @param {number} n          - Number of GWs to return
- * @returns {number[]} GW IDs, most recent first
+ * @returns {number[]} All completed GW IDs before targetGwId, most recent first
  */
 const getRecentCompletedGws = (fixtures, targetGwId) => {
   // Group fixtures by event


### PR DESCRIPTION
This pull request introduces several enhancements to the season data fetching and prediction pipeline, with a focus on improving the reliability and efficiency of player predictions for future gameweeks. The main improvements include pre-computing and caching predictions during the GitHub Actions workflow, serving these cached predictions in the API to reduce computation on cold starts, and refining the backtesting calibration to use all available historical data with exponential decay weighting.

**Prediction caching and serving improvements:**

* The daily data-fetch script (`.github/scripts/fetch-season-data.js`) now pre-computes player predictions for the next or current gameweek, stores them in `seasonData/predictions/gw-{n}.json`, and deletes stale prediction files for concluded gameweeks. This ensures predictions are always up-to-date and avoids serving stale data. [[1]](diffhunk://#diff-9af6a6948b4ed45bb27beba6e2795df4895a9a214aa5c37effca12fec13c8af3R23-R37) [[2]](diffhunk://#diff-9af6a6948b4ed45bb27beba6e2795df4895a9a214aa5c37effca12fec13c8af3L193-R298)
* The FPL API controller (`backend/controllers/fplController.js`) attempts to serve these pre-computed predictions for future gameweeks, falling back to live computation only if the cached predictions are missing or older than 13 hours. This reduces cold start latency and avoids unnecessary heavy computation.
* A new method, `fetchStoredPredictions`, is added to the data provider to load these prediction files when available. [[1]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eR349-R375) [[2]](diffhunk://#diff-1ce9e9c4059c11d4bdf7be1336ec80bb70af818d78592c1a2c3b50791f93930eR455)

**Backtest calibration enhancements:**

* The backtest engine (`backend/models/prediction/backtestEngine.js`) now calibrates using all available completed gameweeks before the target, rather than just the last three, and applies exponential decay weighting so recent GWs have more influence but older data still contributes. This improves the stability and responsiveness of prediction calibration. [[1]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L11-R22) [[2]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L33-R54) [[3]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L72-R80) [[4]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L88-R96) [[5]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L154-R169) [[6]](diffhunk://#diff-87f6f273e0b99e84bf57e0c94eaaacc4e150ac5f18f4b845a0463d0539964962L180-R188)

**Other improvements:**

* The data-fetch script now checks for changes in fixture count before skipping GW live data fetches, ensuring rescheduled matches are always reflected in the data.
* Output summaries in the data-fetch script now include the number of prediction files written.

These changes together make the prediction pipeline more robust, efficient, and accurate, especially around gameweek transitions and fixture rescheduling.