### PR TITLE
Update FPL season data refresh schedule to daily at 08:00 UTC

### DIFF
--- a/.github/workflows/fetch-season-data.yml
+++ b/.github/workflows/fetch-season-data.yml
@@ -11,10 +11,8 @@ name: Refresh FPL Season Data
 
 on:
   schedule:
-    # 06:00 and 18:00 UTC every day — covers pre-deadline and post-results
-    - cron: '0 6,18 * * *'
-  push:
-    branches: [main, master]
+    # 08:00 UTC every day — covers post-results overnight and pre-peak morning
+    - cron: '0 8 * * *'
   workflow_dispatch:     # allow manual trigger from GitHub UI
 
 permissions:

--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -1156,6 +1156,13 @@ const getRecommendedTransfers = async (req, res) => {
 
 /**
  * Calculate cumulative predicted points for a set of player IDs across one or more gameweeks.
+ *
+ * For GW+1 (the most common case), we read the predictions file produced by
+ * the daily CI job (.github/workflows/fetch-season-data.yml, runs at 08:00 UTC).
+ * This avoids running the full Monte Carlo engine on every request.
+ * For additional GWs beyond that file, or when the file is absent, we fall
+ * back to live computation.
+ *
  * @param {Array} allPlayers - Enriched player list
  * @param {Array} fixtures - Fixture list
  * @param {Array} teams - Team list
@@ -1164,11 +1171,22 @@ const getRecommendedTransfers = async (req, res) => {
  * @returns {Object} Map of playerId -> cumulative predicted points
  */
 async function buildPlayerPointsMap(allPlayers, fixtures, teams, currentEventId, gameweeksAhead) {
-  const startEvent = currentEventId + 1;
-  const endEvent = currentEventId + gameweeksAhead;
   const playerPointsMap = {};
+  const startEvent = currentEventId + 1;
+  const endEvent = Math.min(currentEventId + gameweeksAhead, 38);
 
-  for (let gw = startEvent; gw <= Math.min(endEvent, 38); gw++) {
+  for (let gw = startEvent; gw <= endEvent; gw++) {
+    // Try stored predictions for this GW first (written by CI at 08:00 UTC)
+    const stored = await dataProvider.fetchStoredPredictions(gw);
+    if (stored?.players) {
+      Object.entries(stored.players).forEach(([id, pred]) => {
+        const pts = parseFloat(pred.predicted_points ?? pred.ep_next) || 0;
+        playerPointsMap[id] = (playerPointsMap[id] || 0) + pts;
+      });
+      continue;
+    }
+
+    // Fall back to live computation when no stored file exists
     let gwPlayers = allPlayers.map(p => ({ ...p }));
     gwPlayers = fplModel.enrichPlayersWithOpponents(gwPlayers, fixtures, teams, gw);
     gwPlayers = await fplModel.applyAdvancedPredictions(gwPlayers, fixtures, teams, gw);

--- a/backend/controllers/fplController.js
+++ b/backend/controllers/fplController.js
@@ -2,6 +2,13 @@ const fplModel = require('../models/fplModel');
 const dataProvider = require('../models/dataProvider');
 const { buildBreakdown } = require('../utils/statsBreakdown');
 
+// Stored-prediction freshness threshold.  The daily workflow runs at 08:00 UTC
+// (24 h cycle), so we allow up to 25 h before treating a file as stale.  This
+// gives a 1-hour grace period beyond the scheduled cycle and ensures that
+// fixture changes (e.g. postponements) are detected within 25 h of the
+// workflow run.
+const MAX_PREDICTION_AGE_MS = 25 * 60 * 60 * 1000;
+
 /**
  * Format a player's opponent(s) as a human-readable display string.
  * E.g. "MCI (H)" or "LIV (A) ARS (H)" for a DGW.
@@ -745,12 +752,7 @@ const getAllPlayersEnriched = async (req, res) => {
     if (!isPastOrActive) {
       // Try to serve pre-computed predictions written by the daily Actions workflow.
       // This avoids the full backtest + engine run on every cold start.
-      //
-      // Staleness guard: reject files older than 13 h (just over one Actions
-      // interval).  This ensures a fixture postponement or reschedule is picked
-      // up within at most one Actions cycle rather than serving indefinitely
-      // stale predictions.
-      const MAX_PREDICTION_AGE_MS = 13 * 60 * 60 * 1000;
+      // See MAX_PREDICTION_AGE_MS at the top of this module for the staleness threshold.
       const stored = await dataProvider.fetchStoredPredictions(targetEvent);
       const storedAge = stored?.computedAt
         ? Date.now() - new Date(stored.computedAt).getTime()
@@ -1175,18 +1177,34 @@ async function buildPlayerPointsMap(allPlayers, fixtures, teams, currentEventId,
   const startEvent = currentEventId + 1;
   const endEvent = Math.min(currentEventId + gameweeksAhead, 38);
 
+  const playerIdSet = new Set(allPlayers.map(p => String(p.id)));
+
   for (let gw = startEvent; gw <= endEvent; gw++) {
     // Try stored predictions for this GW first (written by CI at 08:00 UTC)
     const stored = await dataProvider.fetchStoredPredictions(gw);
-    if (stored?.players) {
+    const storedAge = stored?.computedAt
+      ? Date.now() - new Date(stored.computedAt).getTime()
+      : Infinity;
+    const storedValid =
+      stored?.players &&
+      Object.keys(stored.players).length > 0 &&
+      storedAge < MAX_PREDICTION_AGE_MS;
+
+    if (storedValid) {
+      console.log(`[transfers] Serving stored predictions for GW${gw} (computed ${stored.computedAt})`);
       Object.entries(stored.players).forEach(([id, pred]) => {
+        if (!playerIdSet.has(String(id))) return;
         const pts = parseFloat(pred.predicted_points ?? pred.ep_next) || 0;
         playerPointsMap[id] = (playerPointsMap[id] || 0) + pts;
       });
       continue;
     }
 
-    // Fall back to live computation when no stored file exists
+    if (stored && storedAge >= MAX_PREDICTION_AGE_MS) {
+      console.warn(`[transfers] Stored predictions for GW${gw} are stale (${Math.round(storedAge / 3600000)}h old) — recomputing.`);
+    }
+
+    // Fall back to live computation when no stored file exists or file is stale
     let gwPlayers = allPlayers.map(p => ({ ...p }));
     gwPlayers = fplModel.enrichPlayersWithOpponents(gwPlayers, fixtures, teams, gw);
     gwPlayers = await fplModel.applyAdvancedPredictions(gwPlayers, fixtures, teams, gw);


### PR DESCRIPTION
This pull request updates the daily FPL season data workflow schedule and improves the efficiency of fetching predicted player points for recommended transfers. The main changes are a shift in the CI job timing and enhancements to the backend controller to use precomputed predictions where possible, reducing live computation.

**Workflow schedule update:**

- Changed the scheduled time for the `.github/workflows/fetch-season-data.yml` CI job from twice daily at 06:00 and 18:00 UTC to once daily at 08:00 UTC, to better align with post-results and pre-peak usage.

**Backend prediction efficiency:**

- Updated documentation and logic in `backend/controllers/fplController.js` to clarify and implement the use of stored player prediction files (generated by the CI job) for the next gameweek, falling back to live computation only when necessary. This should improve response times and reduce server load for the most common use case. [[1]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bR1159-R1165) [[2]](diffhunk://#diff-4d2f1fe17d09beb74448346feaad3a891be16b7a8ac0b9d9526d21b0532f515bL1167-R1189)